### PR TITLE
Capture headers for FII API calls

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/dto/CapturedRequest.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/dto/CapturedRequest.java
@@ -1,0 +1,13 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.fii.dto;
+
+import java.util.Map;
+
+/**
+ * Representa uma requisição interceptada contendo a URL alvo e os
+ * respectivos headers enviados pelo browser. Os headers incluem o
+ * cabeçalho de cookies, permitindo que chamadas subsequentes para as
+ * APIs reproduzam o mesmo contexto de requisição.
+ */
+public record CapturedRequest(String url, Map<String, String> headers) {
+}
+

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/dto/ScrapeResult.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/dto/ScrapeResult.java
@@ -4,8 +4,8 @@ package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.fii.dto;
 import java.util.Map;
 import java.util.Optional;
 
-public  record ScrapeResult(String html, Map<String, String> urlsMapeadas) {
-    public Optional<String> findUrl(String keyword) {
-        return Optional.ofNullable(urlsMapeadas.get(keyword));
+public  record ScrapeResult(String html, Map<String, CapturedRequest> requestsMapeadas) {
+    public Optional<CapturedRequest> findRequest(String keyword) {
+        return Optional.ofNullable(requestsMapeadas.get(keyword));
     }
 }


### PR DESCRIPTION
## Summary
- capture headers and cookies for intercepted requests
- propagate headers to FII API clients
- forward captured headers from Selenium and Playwright adapters

