### PR TITLE
Ativa listener antes da navegação no Playwright

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/FiiPlaywrightDirectScraperAdapter.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/FiiPlaywrightDirectScraperAdapter.java
@@ -152,9 +152,6 @@ public class FiiPlaywrightDirectScraperAdapter extends AbstractScraperAdapter<Fi
                 ctxRef.set(ctx);
                 pageRef.set(page);
 
-                // Navegar e validar usando método da classe base
-                navigateAndValidate(page, url, ticker);
-
                 // Captura de XHR por substring (sem regex)
                 final Map<String, CapturedRequest> requestsMapeadas = new HashMap<>();
                 page.onRequest(req -> {
@@ -167,6 +164,9 @@ public class FiiPlaywrightDirectScraperAdapter extends AbstractScraperAdapter<Fi
                         }
                     }
                 });
+
+                // Navegar e validar usando método da classe base
+                navigateAndValidate(page, url, ticker);
 
                 // Captura paralela de APIs para reduzir tempo de 30s para ~10s (60% de redução)
                 logger.info("Iniciando captura paralela de APIs para {} [correlationId={}]", ticker, correlationId);


### PR DESCRIPTION
## Summary
- Move request listener setup before navigation in `FiiPlaywrightDirectScraperAdapter`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ac96f25b6c832a828fe012abe1ad9c