### PR TITLE
refactor: ensure thread-safe maps

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/mapper/RawDataMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/mapper/RawDataMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -71,7 +72,7 @@ public interface RawDataMapper {
      */
     @Named("buildAcaoRawDataMap")
     default Map<String, Object> buildAcaoRawDataMap(AcaoDadosFinanceirosDTO infraDto) {
-        Map<String, Object> rawData = new HashMap<>();
+        Map<String, Object> rawData = Collections.synchronizedMap(new HashMap<>());
         
         if (infraDto == null) return rawData;
         
@@ -191,7 +192,7 @@ public interface RawDataMapper {
      */
     @Named("buildFiiRawDataMap")
     default Map<String, Object> buildFiiRawDataMap(FiiDadosFinanceirosDTO infraDto) {
-        Map<String, Object> rawData = new HashMap<>();
+        Map<String, Object> rawData = Collections.synchronizedMap(new HashMap<>());
         
         if (infraDto == null) return rawData;
         

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/FiiApiScraper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/FiiApiScraper.java
@@ -12,9 +12,9 @@ import reactor.core.publisher.Mono;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Componente especialista em interagir com as APIs externas de FIIs do Investidor10.
@@ -96,7 +96,7 @@ public class FiiApiScraper {
             return request;
         }
 
-        Map<String, String> headerCopy = new HashMap<>();
+        Map<String, String> headerCopy = new ConcurrentHashMap<>();
         String cookieHeader = null;
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             if ("cookie".equalsIgnoreCase(entry.getKey())) {

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/FiiPlaywrightDirectScraperAdapter.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/fii/FiiPlaywrightDirectScraperAdapter.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.fii.FiiApiConstants.*;
@@ -153,7 +154,7 @@ public class FiiPlaywrightDirectScraperAdapter extends AbstractScraperAdapter<Fi
                 pageRef.set(page);
 
                 // Captura de XHR por substring (sem regex)
-                final Map<String, CapturedRequest> requestsMapeadas = new HashMap<>();
+                final Map<String, CapturedRequest> requestsMapeadas = new ConcurrentHashMap<>();
                 page.onRequest(req -> {
                     String u = req.url();
                     Map<String, String> headers = req.headers();


### PR DESCRIPTION
## Summary
- switch request capture map to ConcurrentHashMap for thread-safe Playwright operations
- use thread-safe map for header copies in Fii API scraper
- wrap raw data maps in synchronized wrappers to retain null values
