### PR TITLE
Increase network capture timeout to 10s

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/base/AbstractScraperAdapter.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/base/AbstractScraperAdapter.java
@@ -46,7 +46,7 @@ public abstract class AbstractScraperAdapter<T> {
     // Configurações padronizadas de timeout para operações assíncronas (OTIMIZADAS)
     protected static final int ASYNC_OPERATION_TIMEOUT_MS = 20_000;  // Reduzido de 45s para 20s (56% redução)
     protected static final int API_CALL_TIMEOUT_MS = 8_000;          // Reduzido de 15s para 8s (47% redução)
-    protected static final int NETWORK_CAPTURE_TIMEOUT_MS = 5_000;   // Reduzido de 10s para 5s (50% redução)
+    protected static int NETWORK_CAPTURE_TIMEOUT_MS = 10_000;        // Aumentado para 10s (configurável)
     protected static final int ELEMENT_WAIT_TIMEOUT_MS = 8_000;      // Reduzido de 10s para 8s (20% redução)
     
     /**

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/base/ScraperTimeoutConfig.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/base/ScraperTimeoutConfig.java
@@ -1,0 +1,16 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.base;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures timeout values for scraper operations using external properties.
+ */
+@Configuration
+public class ScraperTimeoutConfig {
+
+    public ScraperTimeoutConfig(
+            @Value("${scraper.network-capture-timeout-ms:10000}") int networkCaptureTimeout) {
+        AbstractScraperAdapter.NETWORK_CAPTURE_TIMEOUT_MS = networkCaptureTimeout;
+    }
+}

--- a/tickerscraper/src/main/resources/application.yml
+++ b/tickerscraper/src/main/resources/application.yml
@@ -47,6 +47,7 @@ logging:
 
 # Configurações específicas do Scraper
 scraper:
+  network-capture-timeout-ms: ${SCRAPER_NETWORK_CAPTURE_TIMEOUT_MS:10000}
   selenium:
     retry:
       # Configurações para inicialização do WebDriver


### PR DESCRIPTION
## Summary
- raise default network capture timeout to 10 s in `AbstractScraperAdapter`
- allow configuring the timeout via `scraper.network-capture-timeout-ms` property
- wire new property through `ScraperTimeoutConfig`

## Testing
- `mvn -q -f tickerscraper/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9ad72020832a9f1cb3677222e830