### PR TITLE
feat: add BDR domain persistence and mapping support

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/BdrRepositoryAdapter.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/BdrRepositoryAdapter.java
@@ -1,0 +1,128 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrEntity;
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrJpaRepository;
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr.BdrMapper;
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr.JsonMapMapper;
+import br.dev.rodrigopinheiro.tickerscraper.application.dto.PageQuery;
+import br.dev.rodrigopinheiro.tickerscraper.application.dto.PagedResult;
+import br.dev.rodrigopinheiro.tickerscraper.application.port.output.BdrRepositoryPort;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.Bdr;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.TipoAtivo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class BdrRepositoryAdapter implements BdrRepositoryPort {
+
+    private static final Logger logger = LoggerFactory.getLogger(BdrRepositoryAdapter.class);
+
+    private final BdrJpaRepository repository;
+    private final BdrMapper mapper;
+    private final JsonMapMapper jsonMapMapper;
+
+    public BdrRepositoryAdapter(BdrJpaRepository repository, BdrMapper mapper, JsonMapMapper jsonMapMapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+        this.jsonMapMapper = jsonMapMapper;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Bdr> findById(Long id) {
+        return repository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Bdr> findByTicker(String ticker) {
+        return repository.findByTicker(ticker).map(mapper::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Bdr> findByTickerWithDetails(String ticker) {
+        return repository.findDetailedByTicker(ticker).map(mapper::toDomain);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByTicker(String ticker) {
+        return repository.existsByTicker(ticker);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PagedResult<Bdr> findAll(PageQuery query) {
+        Pageable pageable = PageRequest.of(query.pageNumber(), query.pageSize());
+        Page<BdrEntity> page = repository.findAll(pageable);
+        List<Bdr> content = page.getContent().stream().map(mapper::toDomain).toList();
+        return new PagedResult<>(content, page.getTotalElements(), page.getTotalPages(), page.getNumber());
+    }
+
+    @Override
+    @Transactional
+    public Bdr saveReplacingChildren(Bdr bdr, String rawJsonAudit, String rawJsonHash) {
+        logger.debug("Persistindo BDR {} com atualização de coleções", bdr.getTicker());
+        BdrEntity entity = repository.findDetailedByTicker(bdr.getTicker())
+                .orElseGet(() -> mapper.toEntity(bdr));
+
+        if (entity.getId() != null) {
+            mapper.updateEntity(bdr, entity);
+        }
+
+        mapper.replaceAssociations(bdr, entity);
+
+        if (rawJsonAudit != null) {
+            entity.setRawJson(rawJsonAudit);
+        } else if (bdr.getRawJson() != null) {
+            entity.setRawJson(jsonMapMapper.mapToJson(bdr.getRawJson()));
+        }
+
+        if (rawJsonHash != null) {
+            entity.setRawJsonHash(rawJsonHash);
+        } else if (bdr.getRawJsonHash() != null) {
+            entity.setRawJsonHash(bdr.getRawJsonHash());
+        }
+        entity.setUpdatedAt(bdr.getUpdatedAt() == null ? null : bdr.getUpdatedAt().atOffset(ZoneOffset.UTC));
+
+        entity = repository.save(entity);
+        return mapper.toDomain(entity);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<String> findRawJsonByTicker(String ticker) {
+        return repository.findByTicker(ticker).map(BdrEntity::getRawJson);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Bdr> findByTipoAtivo(TipoAtivo tipoAtivo) {
+        return repository.findByTipoAtivo(tipoAtivo).stream().map(mapper::toDomain).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PagedResult<Bdr> findByTipoAtivo(TipoAtivo tipoAtivo, PageQuery query) {
+        Pageable pageable = PageRequest.of(query.pageNumber(), query.pageSize());
+        Page<BdrEntity> page = repository.findByTipoAtivo(tipoAtivo, pageable);
+        List<Bdr> content = page.getContent().stream().map(mapper::toDomain).toList();
+        return new PagedResult<>(content, page.getTotalElements(), page.getTotalPages(), page.getNumber());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countByTipoAtivo(TipoAtivo tipoAtivo) {
+        return repository.countByTipoAtivo(tipoAtivo);
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrBpYearEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrBpYearEntity.java
@@ -1,0 +1,42 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "bdr_bp_year")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrBpYearEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bdr_id")
+    private BdrEntity bdr;
+
+    @Column(name = "ano")
+    private Integer ano;
+
+    @Column(name = "ativos_totais", precision = 19, scale = 2)
+    private BigDecimal ativosTotais;
+
+    @Column(name = "passivos_totais", precision = 19, scale = 2)
+    private BigDecimal passivosTotais;
+
+    @Column(name = "patrimonio_liquido", precision = 19, scale = 2)
+    private BigDecimal patrimonioLiquido;
+
+    @Column(name = "caixa_disponibilidades", precision = 19, scale = 2)
+    private BigDecimal caixaEDisponibilidades;
+
+    @Column(name = "divida_bruta", precision = 19, scale = 2)
+    private BigDecimal dividaBruta;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrCurrentIndicatorsEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrCurrentIndicatorsEntity.java
@@ -1,0 +1,51 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "bdr_current_indicators")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrCurrentIndicatorsEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bdr_id", unique = true)
+    private BdrEntity bdr;
+
+    @Column(name = "ultimo_preco", precision = 19, scale = 6)
+    private BigDecimal ultimoPreco;
+
+    @Column(name = "variacao_dia", precision = 19, scale = 6)
+    private BigDecimal variacaoPercentualDia;
+
+    @Column(name = "variacao_mes", precision = 19, scale = 6)
+    private BigDecimal variacaoPercentualMes;
+
+    @Column(name = "variacao_ano", precision = 19, scale = 6)
+    private BigDecimal variacaoPercentualAno;
+
+    @Column(name = "dividend_yield", precision = 19, scale = 6)
+    private BigDecimal dividendYield;
+
+    @Column(name = "preco_lucro", precision = 19, scale = 6)
+    private BigDecimal precoLucro;
+
+    @Column(name = "preco_valor_patrimonial", precision = 19, scale = 6)
+    private BigDecimal precoValorPatrimonial;
+
+    @Column(name = "valor_mercado", precision = 19, scale = 2)
+    private BigDecimal valorMercado;
+
+    @Column(name = "volume_medio", precision = 19, scale = 2)
+    private BigDecimal volumeMedio;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDividendYearlyEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDividendYearlyEntity.java
@@ -1,0 +1,33 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "bdr_dividend_year")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrDividendYearlyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bdr_id")
+    private BdrEntity bdr;
+
+    @Column(name = "ano")
+    private Integer ano;
+
+    @Column(name = "total_dividendo", precision = 19, scale = 6)
+    private BigDecimal totalDividendo;
+
+    @Column(name = "dividend_yield", precision = 19, scale = 6)
+    private BigDecimal dividendYield;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDreYearEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDreYearEntity.java
@@ -1,0 +1,42 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "bdr_dre_year")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrDreYearEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bdr_id")
+    private BdrEntity bdr;
+
+    @Column(name = "ano")
+    private Integer ano;
+
+    @Column(name = "receita_liquida", precision = 19, scale = 2)
+    private BigDecimal receitaLiquida;
+
+    @Column(name = "lucro_liquido", precision = 19, scale = 2)
+    private BigDecimal lucroLiquido;
+
+    @Column(name = "ebitda", precision = 19, scale = 2)
+    private BigDecimal ebitda;
+
+    @Column(name = "ebit", precision = 19, scale = 2)
+    private BigDecimal ebit;
+
+    @Column(name = "margem_liquida", precision = 19, scale = 6)
+    private BigDecimal margemLiquida;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrEntity.java
@@ -1,0 +1,157 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.TipoAtivo;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "bdr")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ticker", nullable = false, unique = true)
+    private String ticker;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_ativo", length = 20, nullable = false)
+    @Builder.Default
+    private TipoAtivo tipoAtivo = TipoAtivo.BDR;
+
+    @Column(name = "nome_empresa")
+    private String nomeEmpresa;
+
+    @Column(name = "nome_acao_original")
+    private String nomeAcaoOriginal;
+
+    @Column(name = "codigo_negociacao")
+    private String codigoNegociacao;
+
+    @Column(name = "mercado")
+    private String mercado;
+
+    @Column(name = "pais_negociacao")
+    private String paisDeNegociacao;
+
+    @Column(name = "moeda_referencia")
+    private String moedaDeReferencia;
+
+    @Column(name = "preco_atual", precision = 19, scale = 6)
+    private BigDecimal precoAtual;
+
+    @Column(name = "variacao_dia", precision = 19, scale = 6)
+    private BigDecimal variacaoDia;
+
+    @Column(name = "variacao_mes", precision = 19, scale = 6)
+    private BigDecimal variacaoMes;
+
+    @Column(name = "variacao_ano", precision = 19, scale = 6)
+    private BigDecimal variacaoAno;
+
+    @Column(name = "dividend_yield", precision = 19, scale = 6)
+    private BigDecimal dividendYield;
+
+    @Column(name = "preco_alvo", precision = 19, scale = 6)
+    private BigDecimal precoAlvo;
+
+    @OneToMany(
+            mappedBy = "bdr",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @BatchSize(size = 50)
+    @Builder.Default
+    private List<BdrPriceSeriesEntity> priceSeries = new ArrayList<>();
+
+    @OneToMany(
+            mappedBy = "bdr",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @BatchSize(size = 50)
+    @Builder.Default
+    private List<BdrDividendYearlyEntity> dividendYears = new ArrayList<>();
+
+    @OneToMany(
+            mappedBy = "bdr",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @BatchSize(size = 50)
+    @Builder.Default
+    private List<BdrHistoricalIndicatorEntity> historicalIndicators = new ArrayList<>();
+
+    @OneToMany(
+            mappedBy = "bdr",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @BatchSize(size = 50)
+    @Builder.Default
+    private List<BdrDreYearEntity> dreYears = new ArrayList<>();
+
+    @OneToMany(
+            mappedBy = "bdr",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @BatchSize(size = 50)
+    @Builder.Default
+    private List<BdrBpYearEntity> bpYears = new ArrayList<>();
+
+    @OneToMany(
+            mappedBy = "bdr",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @BatchSize(size = 50)
+    @Builder.Default
+    private List<BdrFcYearEntity> fcYears = new ArrayList<>();
+
+    @OneToOne(
+            mappedBy = "bdr",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    private BdrCurrentIndicatorsEntity currentIndicators;
+
+    @OneToOne(
+            mappedBy = "bdr",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    private BdrParidadeEntity paridade;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "raw_json", columnDefinition = "JSONB")
+    private String rawJson;
+
+    @Column(name = "raw_json_hash", length = 128)
+    private String rawJsonHash;
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrFcYearEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrFcYearEntity.java
@@ -1,0 +1,39 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "bdr_fc_year")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrFcYearEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bdr_id")
+    private BdrEntity bdr;
+
+    @Column(name = "ano")
+    private Integer ano;
+
+    @Column(name = "fluxo_operacional", precision = 19, scale = 2)
+    private BigDecimal fluxoCaixaOperacional;
+
+    @Column(name = "fluxo_investimento", precision = 19, scale = 2)
+    private BigDecimal fluxoCaixaInvestimento;
+
+    @Column(name = "fluxo_financiamento", precision = 19, scale = 2)
+    private BigDecimal fluxoCaixaFinanciamento;
+
+    @Column(name = "caixa_final", precision = 19, scale = 2)
+    private BigDecimal caixaFinal;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrHistoricalIndicatorEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrHistoricalIndicatorEntity.java
@@ -1,0 +1,33 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "bdr_historical_indicator")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrHistoricalIndicatorEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bdr_id")
+    private BdrEntity bdr;
+
+    @Column(name = "nome_indicador")
+    private String nomeIndicador;
+
+    @Column(name = "ano")
+    private Integer ano;
+
+    @Column(name = "valor", precision = 19, scale = 6)
+    private BigDecimal valor;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrJpaRepository.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrJpaRepository.java
@@ -1,0 +1,77 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.TipoAtivo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BdrJpaRepository extends JpaRepository<BdrEntity, Long> {
+
+    Optional<BdrEntity> findByTicker(String ticker);
+
+    boolean existsByTicker(String ticker);
+
+    @EntityGraph(attributePaths = {
+            "priceSeries",
+            "dividendYears",
+            "historicalIndicators",
+            "dreYears",
+            "bpYears",
+            "fcYears",
+            "currentIndicators",
+            "paridade"
+    })
+    @Query("""
+            select distinct b
+            from BdrEntity b
+            where b.ticker = :ticker
+            """)
+    Optional<BdrEntity> findDetailedByTicker(@Param("ticker") String ticker);
+
+    @EntityGraph(attributePaths = {
+            "priceSeries",
+            "dividendYears",
+            "historicalIndicators",
+            "dreYears",
+            "bpYears",
+            "fcYears",
+            "currentIndicators",
+            "paridade"
+    })
+    @Override
+    Page<BdrEntity> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = {
+            "priceSeries",
+            "dividendYears",
+            "historicalIndicators",
+            "dreYears",
+            "bpYears",
+            "fcYears",
+            "currentIndicators",
+            "paridade"
+    })
+    List<BdrEntity> findByTipoAtivo(TipoAtivo tipoAtivo);
+
+    @EntityGraph(attributePaths = {
+            "priceSeries",
+            "dividendYears",
+            "historicalIndicators",
+            "dreYears",
+            "bpYears",
+            "fcYears",
+            "currentIndicators",
+            "paridade"
+    })
+    Page<BdrEntity> findByTipoAtivo(TipoAtivo tipoAtivo, Pageable pageable);
+
+    long countByTipoAtivo(TipoAtivo tipoAtivo);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrParidadeEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrParidadeEntity.java
@@ -1,0 +1,36 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "bdr_paridade")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrParidadeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bdr_id", unique = true)
+    private BdrEntity bdr;
+
+    @Column(name = "fator_conversao", precision = 19, scale = 6)
+    private BigDecimal fatorConversao;
+
+    @Column(name = "ticker_original")
+    private String tickerOriginal;
+
+    @Column(name = "bolsa_origem")
+    private String bolsaOrigem;
+
+    @Column(name = "moeda_origem")
+    private String moedaOrigem;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrPriceSeriesEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrPriceSeriesEntity.java
@@ -1,0 +1,43 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "bdr_price_series")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BdrPriceSeriesEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bdr_id")
+    private BdrEntity bdr;
+
+    @Column(name = "timestamp")
+    private OffsetDateTime timestamp;
+
+    @Column(name = "open_price", precision = 19, scale = 6)
+    private BigDecimal openPrice;
+
+    @Column(name = "high_price", precision = 19, scale = 6)
+    private BigDecimal highPrice;
+
+    @Column(name = "low_price", precision = 19, scale = 6)
+    private BigDecimal lowPrice;
+
+    @Column(name = "close_price", precision = 19, scale = 6)
+    private BigDecimal closePrice;
+
+    @Column(name = "volume", precision = 19, scale = 6)
+    private BigDecimal volume;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrCurrentIndicatorsMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrCurrentIndicatorsMapper.java
@@ -1,0 +1,21 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrCurrentIndicatorsEntity;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.CurrentIndicators;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+@Mapper(componentModel = "spring")
+public interface BdrCurrentIndicatorsMapper {
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "bdr", ignore = true)
+    })
+    BdrCurrentIndicatorsEntity toEntity(CurrentIndicators indicators);
+
+    @InheritInverseConfiguration
+    CurrentIndicators toDomain(BdrCurrentIndicatorsEntity entity);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrDividendYearMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrDividendYearMapper.java
@@ -1,0 +1,30 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrDividendYearlyEntity;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.DividendYear;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BdrDividendYearMapper {
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "bdr", ignore = true),
+            @Mapping(source = "ano", target = "ano"),
+            @Mapping(source = "totalDividendo", target = "totalDividendo"),
+            @Mapping(source = "dividendYield", target = "dividendYield")
+    })
+    BdrDividendYearlyEntity toEntity(DividendYear year);
+
+    @InheritInverseConfiguration
+    DividendYear toDomain(BdrDividendYearlyEntity entity);
+
+    List<BdrDividendYearlyEntity> toEntityList(List<DividendYear> source);
+
+    List<DividendYear> toDomainList(List<BdrDividendYearlyEntity> source);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrFinancialStatementMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrFinancialStatementMapper.java
@@ -1,0 +1,57 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrBpYearEntity;
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrDreYearEntity;
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrFcYearEntity;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.BpYear;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.DreYear;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.FcYear;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BdrFinancialStatementMapper {
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "bdr", ignore = true)
+    })
+    BdrDreYearEntity toEntity(DreYear year);
+
+    @InheritInverseConfiguration
+    DreYear toDomain(BdrDreYearEntity entity);
+
+    List<BdrDreYearEntity> toDreEntityList(List<DreYear> source);
+
+    List<DreYear> toDreDomainList(List<BdrDreYearEntity> source);
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "bdr", ignore = true)
+    })
+    BdrBpYearEntity toEntity(BpYear year);
+
+    @InheritInverseConfiguration
+    BpYear toDomain(BdrBpYearEntity entity);
+
+    List<BdrBpYearEntity> toBpEntityList(List<BpYear> source);
+
+    List<BpYear> toBpDomainList(List<BdrBpYearEntity> source);
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "bdr", ignore = true)
+    })
+    BdrFcYearEntity toEntity(FcYear year);
+
+    @InheritInverseConfiguration
+    FcYear toDomain(BdrFcYearEntity entity);
+
+    List<BdrFcYearEntity> toFcEntityList(List<FcYear> source);
+
+    List<FcYear> toFcDomainList(List<BdrFcYearEntity> source);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrHistoricalIndicatorMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrHistoricalIndicatorMapper.java
@@ -1,0 +1,30 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrHistoricalIndicatorEntity;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.HistoricalIndicator;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BdrHistoricalIndicatorMapper {
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "bdr", ignore = true),
+            @Mapping(source = "nomeIndicador", target = "nomeIndicador"),
+            @Mapping(source = "ano", target = "ano"),
+            @Mapping(source = "valor", target = "valor")
+    })
+    BdrHistoricalIndicatorEntity toEntity(HistoricalIndicator indicator);
+
+    @InheritInverseConfiguration
+    HistoricalIndicator toDomain(BdrHistoricalIndicatorEntity entity);
+
+    List<BdrHistoricalIndicatorEntity> toEntityList(List<HistoricalIndicator> source);
+
+    List<HistoricalIndicator> toDomainList(List<BdrHistoricalIndicatorEntity> source);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrMapper.java
@@ -1,0 +1,284 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.*;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.*;
+import org.hibernate.LazyInitializationException;
+import org.mapstruct.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Mapper(componentModel = "spring",
+        uses = {
+                TimeMapper.class,
+                JsonMapMapper.class,
+                BdrPriceSeriesMapper.class,
+                BdrDividendYearMapper.class,
+                BdrHistoricalIndicatorMapper.class,
+                BdrFinancialStatementMapper.class,
+                BdrCurrentIndicatorsMapper.class,
+                BdrParidadeMapper.class
+        })
+public interface BdrMapper {
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(source = "ticker", target = "ticker"),
+            @Mapping(source = "tipoAtivo", target = "tipoAtivo"),
+            @Mapping(source = "nomeEmpresa", target = "nomeEmpresa"),
+            @Mapping(source = "nomeAcaoOriginal", target = "nomeAcaoOriginal"),
+            @Mapping(source = "codigoNegociacao", target = "codigoNegociacao"),
+            @Mapping(source = "mercado", target = "mercado"),
+            @Mapping(source = "paisDeNegociacao", target = "paisDeNegociacao"),
+            @Mapping(source = "moedaDeReferencia", target = "moedaDeReferencia"),
+            @Mapping(source = "precoAtual", target = "precoAtual"),
+            @Mapping(source = "variacaoDia", target = "variacaoDia"),
+            @Mapping(source = "variacaoMes", target = "variacaoMes"),
+            @Mapping(source = "variacaoAno", target = "variacaoAno"),
+            @Mapping(source = "dividendYield", target = "dividendYield"),
+            @Mapping(source = "precoAlvo", target = "precoAlvo"),
+            @Mapping(source = "historicoDePrecos", target = "priceSeries"),
+            @Mapping(source = "dividendosPorAno", target = "dividendYears"),
+            @Mapping(source = "indicadoresHistoricos", target = "historicalIndicators"),
+            @Mapping(source = "dreAnual", target = "dreYears"),
+            @Mapping(source = "bpAnual", target = "bpYears"),
+            @Mapping(source = "fcAnual", target = "fcYears"),
+            @Mapping(source = "currentIndicators", target = "currentIndicators"),
+            @Mapping(source = "paridade", target = "paridade"),
+            @Mapping(source = "updatedAt", target = "updatedAt"),
+            @Mapping(source = "rawJson", target = "rawJson", qualifiedByName = "mapToJson"),
+            @Mapping(source = "rawJsonHash", target = "rawJsonHash")
+    })
+    BdrEntity toEntity(Bdr bdr);
+
+    @InheritInverseConfiguration
+    @Mappings({
+            @Mapping(source = "priceSeries", target = "historicoDePrecos"),
+            @Mapping(source = "dividendYears", target = "dividendosPorAno"),
+            @Mapping(source = "historicalIndicators", target = "indicadoresHistoricos"),
+            @Mapping(source = "dreYears", target = "dreAnual"),
+            @Mapping(source = "bpYears", target = "bpAnual"),
+            @Mapping(source = "fcYears", target = "fcAnual"),
+            @Mapping(source = "rawJson", target = "rawJson", qualifiedByName = "jsonToMap")
+    })
+    Bdr toDomain(BdrEntity entity);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "priceSeries", ignore = true),
+            @Mapping(target = "dividendYears", ignore = true),
+            @Mapping(target = "historicalIndicators", ignore = true),
+            @Mapping(target = "dreYears", ignore = true),
+            @Mapping(target = "bpYears", ignore = true),
+            @Mapping(target = "fcYears", ignore = true),
+            @Mapping(target = "currentIndicators", ignore = true),
+            @Mapping(target = "paridade", ignore = true),
+            @Mapping(target = "rawJson", ignore = true),
+            @Mapping(target = "rawJsonHash", ignore = true)
+    })
+    void updateEntity(Bdr source, @MappingTarget BdrEntity target);
+
+    default void replaceAssociations(Bdr source, @MappingTarget BdrEntity target) {
+        replacePriceSeries(source, target);
+        replaceDividendYears(source, target);
+        replaceHistoricalIndicators(source, target);
+        replaceDreYears(source, target);
+        replaceBpYears(source, target);
+        replaceFcYears(source, target);
+        replaceCurrentIndicators(source, target);
+        replaceParidade(source, target);
+    }
+
+    default void replacePriceSeries(Bdr source, BdrEntity target) {
+        if (target.getPriceSeries() == null) {
+            target.setPriceSeries(new ArrayList<>());
+        } else {
+            target.getPriceSeries().clear();
+        }
+        List<PricePoint> pricePoints = source.getHistoricoDePrecos();
+        if (pricePoints != null) {
+            List<BdrPriceSeriesEntity> entities = toPriceSeriesEntities(pricePoints);
+            for (BdrPriceSeriesEntity entity : entities) {
+                entity.setBdr(target);
+                target.getPriceSeries().add(entity);
+            }
+        }
+    }
+
+    default void replaceDividendYears(Bdr source, BdrEntity target) {
+        if (target.getDividendYears() == null) {
+            target.setDividendYears(new ArrayList<>());
+        } else {
+            target.getDividendYears().clear();
+        }
+        List<DividendYear> dividendYears = source.getDividendosPorAno();
+        if (dividendYears != null) {
+            List<BdrDividendYearlyEntity> entities = toDividendYearEntities(dividendYears);
+            for (BdrDividendYearlyEntity entity : entities) {
+                entity.setBdr(target);
+                target.getDividendYears().add(entity);
+            }
+        }
+    }
+
+    default void replaceHistoricalIndicators(Bdr source, BdrEntity target) {
+        if (target.getHistoricalIndicators() == null) {
+            target.setHistoricalIndicators(new ArrayList<>());
+        } else {
+            target.getHistoricalIndicators().clear();
+        }
+        List<HistoricalIndicator> indicators = source.getIndicadoresHistoricos();
+        if (indicators != null) {
+            List<BdrHistoricalIndicatorEntity> entities = toHistoricalIndicatorEntities(indicators);
+            for (BdrHistoricalIndicatorEntity entity : entities) {
+                entity.setBdr(target);
+                target.getHistoricalIndicators().add(entity);
+            }
+        }
+    }
+
+    default void replaceDreYears(Bdr source, BdrEntity target) {
+        if (target.getDreYears() == null) {
+            target.setDreYears(new ArrayList<>());
+        } else {
+            target.getDreYears().clear();
+        }
+        List<DreYear> dreYears = source.getDreAnual();
+        if (dreYears != null) {
+            List<BdrDreYearEntity> entities = toDreEntities(dreYears);
+            for (BdrDreYearEntity entity : entities) {
+                entity.setBdr(target);
+                target.getDreYears().add(entity);
+            }
+        }
+    }
+
+    default void replaceBpYears(Bdr source, BdrEntity target) {
+        if (target.getBpYears() == null) {
+            target.setBpYears(new ArrayList<>());
+        } else {
+            target.getBpYears().clear();
+        }
+        List<BpYear> bpYears = source.getBpAnual();
+        if (bpYears != null) {
+            List<BdrBpYearEntity> entities = toBpEntities(bpYears);
+            for (BdrBpYearEntity entity : entities) {
+                entity.setBdr(target);
+                target.getBpYears().add(entity);
+            }
+        }
+    }
+
+    default void replaceFcYears(Bdr source, BdrEntity target) {
+        if (target.getFcYears() == null) {
+            target.setFcYears(new ArrayList<>());
+        } else {
+            target.getFcYears().clear();
+        }
+        List<FcYear> fcYears = source.getFcAnual();
+        if (fcYears != null) {
+            List<BdrFcYearEntity> entities = toFcEntities(fcYears);
+            for (BdrFcYearEntity entity : entities) {
+                entity.setBdr(target);
+                target.getFcYears().add(entity);
+            }
+        }
+    }
+
+    default void replaceCurrentIndicators(Bdr source, BdrEntity target) {
+        CurrentIndicators indicators = source.getCurrentIndicators();
+        if (indicators == null) {
+            target.setCurrentIndicators(null);
+            return;
+        }
+        BdrCurrentIndicatorsEntity entity = toCurrentIndicatorsEntity(indicators);
+        entity.setBdr(target);
+        target.setCurrentIndicators(entity);
+    }
+
+    default void replaceParidade(Bdr source, BdrEntity target) {
+        ParidadeBdr paridade = source.getParidade();
+        if (paridade == null) {
+            target.setParidade(null);
+            return;
+        }
+        BdrParidadeEntity entity = toParidadeEntity(paridade);
+        entity.setBdr(target);
+        target.setParidade(entity);
+    }
+
+    List<BdrPriceSeriesEntity> toPriceSeriesEntities(List<PricePoint> source);
+
+    List<BdrDividendYearlyEntity> toDividendYearEntities(List<DividendYear> source);
+
+    List<BdrHistoricalIndicatorEntity> toHistoricalIndicatorEntities(List<HistoricalIndicator> source);
+
+    List<BdrDreYearEntity> toDreEntities(List<DreYear> source);
+
+    List<BdrBpYearEntity> toBpEntities(List<BpYear> source);
+
+    List<BdrFcYearEntity> toFcEntities(List<FcYear> source);
+
+    BdrCurrentIndicatorsEntity toCurrentIndicatorsEntity(CurrentIndicators indicators);
+
+    BdrParidadeEntity toParidadeEntity(ParidadeBdr paridade);
+
+    @AfterMapping
+    default void wireParents(@MappingTarget BdrEntity entity) {
+        try {
+            if (entity.getPriceSeries() != null) {
+                for (BdrPriceSeriesEntity child : entity.getPriceSeries()) {
+                    child.setBdr(entity);
+                }
+            }
+        } catch (LazyInitializationException ignored) {
+        }
+        try {
+            if (entity.getDividendYears() != null) {
+                for (BdrDividendYearlyEntity child : entity.getDividendYears()) {
+                    child.setBdr(entity);
+                }
+            }
+        } catch (LazyInitializationException ignored) {
+        }
+        try {
+            if (entity.getHistoricalIndicators() != null) {
+                for (BdrHistoricalIndicatorEntity child : entity.getHistoricalIndicators()) {
+                    child.setBdr(entity);
+                }
+            }
+        } catch (LazyInitializationException ignored) {
+        }
+        try {
+            if (entity.getDreYears() != null) {
+                for (BdrDreYearEntity child : entity.getDreYears()) {
+                    child.setBdr(entity);
+                }
+            }
+        } catch (LazyInitializationException ignored) {
+        }
+        try {
+            if (entity.getBpYears() != null) {
+                for (BdrBpYearEntity child : entity.getBpYears()) {
+                    child.setBdr(entity);
+                }
+            }
+        } catch (LazyInitializationException ignored) {
+        }
+        try {
+            if (entity.getFcYears() != null) {
+                for (BdrFcYearEntity child : entity.getFcYears()) {
+                    child.setBdr(entity);
+                }
+            }
+        } catch (LazyInitializationException ignored) {
+        }
+        if (entity.getCurrentIndicators() != null) {
+            entity.getCurrentIndicators().setBdr(entity);
+        }
+        if (entity.getParidade() != null) {
+            entity.getParidade().setBdr(entity);
+        }
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrParidadeMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrParidadeMapper.java
@@ -1,0 +1,21 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrParidadeEntity;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.ParidadeBdr;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+@Mapper(componentModel = "spring")
+public interface BdrParidadeMapper {
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "bdr", ignore = true)
+    })
+    BdrParidadeEntity toEntity(ParidadeBdr paridade);
+
+    @InheritInverseConfiguration
+    ParidadeBdr toDomain(BdrParidadeEntity entity);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrPriceSeriesMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrPriceSeriesMapper.java
@@ -1,0 +1,33 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrPriceSeriesEntity;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.PricePoint;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", uses = TimeMapper.class)
+public interface BdrPriceSeriesMapper {
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "bdr", ignore = true),
+            @Mapping(source = "timestamp", target = "timestamp"),
+            @Mapping(source = "openPrice", target = "openPrice"),
+            @Mapping(source = "highPrice", target = "highPrice"),
+            @Mapping(source = "lowPrice", target = "lowPrice"),
+            @Mapping(source = "closePrice", target = "closePrice"),
+            @Mapping(source = "volume", target = "volume")
+    })
+    BdrPriceSeriesEntity toEntity(PricePoint point);
+
+    @InheritInverseConfiguration
+    PricePoint toDomain(BdrPriceSeriesEntity entity);
+
+    List<BdrPriceSeriesEntity> toEntityList(List<PricePoint> source);
+
+    List<PricePoint> toDomainList(List<BdrPriceSeriesEntity> source);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/JsonMapMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/JsonMapMapper.java
@@ -1,0 +1,40 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.Named;
+
+import java.util.Map;
+
+@Mapper(componentModel = "spring")
+public interface JsonMapMapper {
+
+    ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Named("mapToJson")
+    default String mapToJson(Map<String, Object> source) {
+        if (source == null || source.isEmpty()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(source);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to serialize rawJson map", e);
+        }
+    }
+
+    @Named("jsonToMap")
+    default Map<String, Object> jsonToMap(String json) {
+        if (json == null || json.isBlank()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readValue(json, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to deserialize rawJson json", e);
+        }
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/TimeMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/TimeMapper.java
@@ -1,0 +1,19 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
+
+import org.mapstruct.Mapper;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Mapper(componentModel = "spring")
+public interface TimeMapper {
+
+    default OffsetDateTime toOffsetDateTime(Instant instant) {
+        return instant == null ? null : instant.atOffset(ZoneOffset.UTC);
+    }
+
+    default Instant toInstant(OffsetDateTime offsetDateTime) {
+        return offsetDateTime == null ? null : offsetDateTime.toInstant();
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/port/output/BdrRepositoryPort.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/port/output/BdrRepositoryPort.java
@@ -1,0 +1,32 @@
+package br.dev.rodrigopinheiro.tickerscraper.application.port.output;
+
+import br.dev.rodrigopinheiro.tickerscraper.application.dto.PageQuery;
+import br.dev.rodrigopinheiro.tickerscraper.application.dto.PagedResult;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.Bdr;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.TipoAtivo;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BdrRepositoryPort {
+
+    Optional<Bdr> findById(Long id);
+
+    Optional<Bdr> findByTicker(String ticker);
+
+    Optional<Bdr> findByTickerWithDetails(String ticker);
+
+    boolean existsByTicker(String ticker);
+
+    PagedResult<Bdr> findAll(PageQuery query);
+
+    Bdr saveReplacingChildren(Bdr bdr, String rawJsonAudit, String rawJsonHash);
+
+    Optional<String> findRawJsonByTicker(String ticker);
+
+    List<Bdr> findByTipoAtivo(TipoAtivo tipoAtivo);
+
+    PagedResult<Bdr> findByTipoAtivo(TipoAtivo tipoAtivo, PageQuery query);
+
+    long countByTipoAtivo(TipoAtivo tipoAtivo);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/Bdr.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/Bdr.java
@@ -1,0 +1,237 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.TipoAtivo;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public class Bdr {
+
+    private String ticker;
+    private String nomeEmpresa;
+    private String nomeAcaoOriginal;
+    private String codigoNegociacao;
+    private String mercado;
+    private String paisDeNegociacao;
+    private String moedaDeReferencia;
+    private BigDecimal precoAtual;
+    private BigDecimal variacaoDia;
+    private BigDecimal variacaoMes;
+    private BigDecimal variacaoAno;
+    private BigDecimal dividendYield;
+    private BigDecimal precoAlvo;
+    private TipoAtivo tipoAtivo = TipoAtivo.BDR;
+    private ParidadeBdr paridade;
+    private CurrentIndicators currentIndicators;
+    private List<PricePoint> historicoDePrecos;
+    private List<DividendYear> dividendosPorAno;
+    private List<HistoricalIndicator> indicadoresHistoricos;
+    private List<DreYear> dreAnual;
+    private List<BpYear> bpAnual;
+    private List<FcYear> fcAnual;
+    private Instant updatedAt;
+    private Map<String, Object> rawJson;
+    private String rawJsonHash;
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public void setTicker(String ticker) {
+        this.ticker = ticker == null ? null : ticker.trim().toUpperCase();
+    }
+
+    public String getNomeEmpresa() {
+        return nomeEmpresa;
+    }
+
+    public void setNomeEmpresa(String nomeEmpresa) {
+        this.nomeEmpresa = nomeEmpresa;
+    }
+
+    public String getNomeAcaoOriginal() {
+        return nomeAcaoOriginal;
+    }
+
+    public void setNomeAcaoOriginal(String nomeAcaoOriginal) {
+        this.nomeAcaoOriginal = nomeAcaoOriginal;
+    }
+
+    public String getCodigoNegociacao() {
+        return codigoNegociacao;
+    }
+
+    public void setCodigoNegociacao(String codigoNegociacao) {
+        this.codigoNegociacao = codigoNegociacao;
+    }
+
+    public String getMercado() {
+        return mercado;
+    }
+
+    public void setMercado(String mercado) {
+        this.mercado = mercado;
+    }
+
+    public String getPaisDeNegociacao() {
+        return paisDeNegociacao;
+    }
+
+    public void setPaisDeNegociacao(String paisDeNegociacao) {
+        this.paisDeNegociacao = paisDeNegociacao;
+    }
+
+    public String getMoedaDeReferencia() {
+        return moedaDeReferencia;
+    }
+
+    public void setMoedaDeReferencia(String moedaDeReferencia) {
+        this.moedaDeReferencia = moedaDeReferencia;
+    }
+
+    public BigDecimal getPrecoAtual() {
+        return precoAtual;
+    }
+
+    public void setPrecoAtual(BigDecimal precoAtual) {
+        this.precoAtual = precoAtual;
+    }
+
+    public BigDecimal getVariacaoDia() {
+        return variacaoDia;
+    }
+
+    public void setVariacaoDia(BigDecimal variacaoDia) {
+        this.variacaoDia = variacaoDia;
+    }
+
+    public BigDecimal getVariacaoMes() {
+        return variacaoMes;
+    }
+
+    public void setVariacaoMes(BigDecimal variacaoMes) {
+        this.variacaoMes = variacaoMes;
+    }
+
+    public BigDecimal getVariacaoAno() {
+        return variacaoAno;
+    }
+
+    public void setVariacaoAno(BigDecimal variacaoAno) {
+        this.variacaoAno = variacaoAno;
+    }
+
+    public BigDecimal getDividendYield() {
+        return dividendYield;
+    }
+
+    public void setDividendYield(BigDecimal dividendYield) {
+        this.dividendYield = dividendYield;
+    }
+
+    public BigDecimal getPrecoAlvo() {
+        return precoAlvo;
+    }
+
+    public void setPrecoAlvo(BigDecimal precoAlvo) {
+        this.precoAlvo = precoAlvo;
+    }
+
+    public TipoAtivo getTipoAtivo() {
+        return tipoAtivo;
+    }
+
+    public void setTipoAtivo(TipoAtivo tipoAtivo) {
+        this.tipoAtivo = tipoAtivo;
+    }
+
+    public ParidadeBdr getParidade() {
+        return paridade;
+    }
+
+    public void setParidade(ParidadeBdr paridade) {
+        this.paridade = paridade;
+    }
+
+    public CurrentIndicators getCurrentIndicators() {
+        return currentIndicators;
+    }
+
+    public void setCurrentIndicators(CurrentIndicators currentIndicators) {
+        this.currentIndicators = currentIndicators;
+    }
+
+    public List<PricePoint> getHistoricoDePrecos() {
+        return historicoDePrecos;
+    }
+
+    public void setHistoricoDePrecos(List<PricePoint> historicoDePrecos) {
+        this.historicoDePrecos = historicoDePrecos;
+    }
+
+    public List<DividendYear> getDividendosPorAno() {
+        return dividendosPorAno;
+    }
+
+    public void setDividendosPorAno(List<DividendYear> dividendosPorAno) {
+        this.dividendosPorAno = dividendosPorAno;
+    }
+
+    public List<HistoricalIndicator> getIndicadoresHistoricos() {
+        return indicadoresHistoricos;
+    }
+
+    public void setIndicadoresHistoricos(List<HistoricalIndicator> indicadoresHistoricos) {
+        this.indicadoresHistoricos = indicadoresHistoricos;
+    }
+
+    public List<DreYear> getDreAnual() {
+        return dreAnual;
+    }
+
+    public void setDreAnual(List<DreYear> dreAnual) {
+        this.dreAnual = dreAnual;
+    }
+
+    public List<BpYear> getBpAnual() {
+        return bpAnual;
+    }
+
+    public void setBpAnual(List<BpYear> bpAnual) {
+        this.bpAnual = bpAnual;
+    }
+
+    public List<FcYear> getFcAnual() {
+        return fcAnual;
+    }
+
+    public void setFcAnual(List<FcYear> fcAnual) {
+        this.fcAnual = fcAnual;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Map<String, Object> getRawJson() {
+        return rawJson;
+    }
+
+    public void setRawJson(Map<String, Object> rawJson) {
+        this.rawJson = rawJson;
+    }
+
+    public String getRawJsonHash() {
+        return rawJsonHash;
+    }
+
+    public void setRawJsonHash(String rawJsonHash) {
+        this.rawJsonHash = rawJsonHash;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/BpYear.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/BpYear.java
@@ -1,0 +1,61 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+public class BpYear {
+
+    private Integer ano;
+    private BigDecimal ativosTotais;
+    private BigDecimal passivosTotais;
+    private BigDecimal patrimonioLiquido;
+    private BigDecimal caixaEDisponibilidades;
+    private BigDecimal dividaBruta;
+
+    public Integer getAno() {
+        return ano;
+    }
+
+    public void setAno(Integer ano) {
+        this.ano = ano;
+    }
+
+    public BigDecimal getAtivosTotais() {
+        return ativosTotais;
+    }
+
+    public void setAtivosTotais(BigDecimal ativosTotais) {
+        this.ativosTotais = ativosTotais;
+    }
+
+    public BigDecimal getPassivosTotais() {
+        return passivosTotais;
+    }
+
+    public void setPassivosTotais(BigDecimal passivosTotais) {
+        this.passivosTotais = passivosTotais;
+    }
+
+    public BigDecimal getPatrimonioLiquido() {
+        return patrimonioLiquido;
+    }
+
+    public void setPatrimonioLiquido(BigDecimal patrimonioLiquido) {
+        this.patrimonioLiquido = patrimonioLiquido;
+    }
+
+    public BigDecimal getCaixaEDisponibilidades() {
+        return caixaEDisponibilidades;
+    }
+
+    public void setCaixaEDisponibilidades(BigDecimal caixaEDisponibilidades) {
+        this.caixaEDisponibilidades = caixaEDisponibilidades;
+    }
+
+    public BigDecimal getDividaBruta() {
+        return dividaBruta;
+    }
+
+    public void setDividaBruta(BigDecimal dividaBruta) {
+        this.dividaBruta = dividaBruta;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/CurrentIndicators.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/CurrentIndicators.java
@@ -1,0 +1,88 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+public class CurrentIndicators {
+
+    private BigDecimal ultimoPreco;
+    private BigDecimal variacaoPercentualDia;
+    private BigDecimal variacaoPercentualMes;
+    private BigDecimal variacaoPercentualAno;
+    private BigDecimal dividendYield;
+    private BigDecimal precoLucro;
+    private BigDecimal precoValorPatrimonial;
+    private BigDecimal valorMercado;
+    private BigDecimal volumeMedio;
+
+    public BigDecimal getUltimoPreco() {
+        return ultimoPreco;
+    }
+
+    public void setUltimoPreco(BigDecimal ultimoPreco) {
+        this.ultimoPreco = ultimoPreco;
+    }
+
+    public BigDecimal getVariacaoPercentualDia() {
+        return variacaoPercentualDia;
+    }
+
+    public void setVariacaoPercentualDia(BigDecimal variacaoPercentualDia) {
+        this.variacaoPercentualDia = variacaoPercentualDia;
+    }
+
+    public BigDecimal getVariacaoPercentualMes() {
+        return variacaoPercentualMes;
+    }
+
+    public void setVariacaoPercentualMes(BigDecimal variacaoPercentualMes) {
+        this.variacaoPercentualMes = variacaoPercentualMes;
+    }
+
+    public BigDecimal getVariacaoPercentualAno() {
+        return variacaoPercentualAno;
+    }
+
+    public void setVariacaoPercentualAno(BigDecimal variacaoPercentualAno) {
+        this.variacaoPercentualAno = variacaoPercentualAno;
+    }
+
+    public BigDecimal getDividendYield() {
+        return dividendYield;
+    }
+
+    public void setDividendYield(BigDecimal dividendYield) {
+        this.dividendYield = dividendYield;
+    }
+
+    public BigDecimal getPrecoLucro() {
+        return precoLucro;
+    }
+
+    public void setPrecoLucro(BigDecimal precoLucro) {
+        this.precoLucro = precoLucro;
+    }
+
+    public BigDecimal getPrecoValorPatrimonial() {
+        return precoValorPatrimonial;
+    }
+
+    public void setPrecoValorPatrimonial(BigDecimal precoValorPatrimonial) {
+        this.precoValorPatrimonial = precoValorPatrimonial;
+    }
+
+    public BigDecimal getValorMercado() {
+        return valorMercado;
+    }
+
+    public void setValorMercado(BigDecimal valorMercado) {
+        this.valorMercado = valorMercado;
+    }
+
+    public BigDecimal getVolumeMedio() {
+        return volumeMedio;
+    }
+
+    public void setVolumeMedio(BigDecimal volumeMedio) {
+        this.volumeMedio = volumeMedio;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DividendYear.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DividendYear.java
@@ -1,0 +1,34 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+public class DividendYear {
+
+    private Integer ano;
+    private BigDecimal totalDividendo;
+    private BigDecimal dividendYield;
+
+    public Integer getAno() {
+        return ano;
+    }
+
+    public void setAno(Integer ano) {
+        this.ano = ano;
+    }
+
+    public BigDecimal getTotalDividendo() {
+        return totalDividendo;
+    }
+
+    public void setTotalDividendo(BigDecimal totalDividendo) {
+        this.totalDividendo = totalDividendo;
+    }
+
+    public BigDecimal getDividendYield() {
+        return dividendYield;
+    }
+
+    public void setDividendYield(BigDecimal dividendYield) {
+        this.dividendYield = dividendYield;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DreYear.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DreYear.java
@@ -1,0 +1,61 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+public class DreYear {
+
+    private Integer ano;
+    private BigDecimal receitaLiquida;
+    private BigDecimal lucroLiquido;
+    private BigDecimal ebitda;
+    private BigDecimal ebit;
+    private BigDecimal margemLiquida;
+
+    public Integer getAno() {
+        return ano;
+    }
+
+    public void setAno(Integer ano) {
+        this.ano = ano;
+    }
+
+    public BigDecimal getReceitaLiquida() {
+        return receitaLiquida;
+    }
+
+    public void setReceitaLiquida(BigDecimal receitaLiquida) {
+        this.receitaLiquida = receitaLiquida;
+    }
+
+    public BigDecimal getLucroLiquido() {
+        return lucroLiquido;
+    }
+
+    public void setLucroLiquido(BigDecimal lucroLiquido) {
+        this.lucroLiquido = lucroLiquido;
+    }
+
+    public BigDecimal getEbitda() {
+        return ebitda;
+    }
+
+    public void setEbitda(BigDecimal ebitda) {
+        this.ebitda = ebitda;
+    }
+
+    public BigDecimal getEbit() {
+        return ebit;
+    }
+
+    public void setEbit(BigDecimal ebit) {
+        this.ebit = ebit;
+    }
+
+    public BigDecimal getMargemLiquida() {
+        return margemLiquida;
+    }
+
+    public void setMargemLiquida(BigDecimal margemLiquida) {
+        this.margemLiquida = margemLiquida;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/FcYear.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/FcYear.java
@@ -1,0 +1,52 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+public class FcYear {
+
+    private Integer ano;
+    private BigDecimal fluxoCaixaOperacional;
+    private BigDecimal fluxoCaixaInvestimento;
+    private BigDecimal fluxoCaixaFinanciamento;
+    private BigDecimal caixaFinal;
+
+    public Integer getAno() {
+        return ano;
+    }
+
+    public void setAno(Integer ano) {
+        this.ano = ano;
+    }
+
+    public BigDecimal getFluxoCaixaOperacional() {
+        return fluxoCaixaOperacional;
+    }
+
+    public void setFluxoCaixaOperacional(BigDecimal fluxoCaixaOperacional) {
+        this.fluxoCaixaOperacional = fluxoCaixaOperacional;
+    }
+
+    public BigDecimal getFluxoCaixaInvestimento() {
+        return fluxoCaixaInvestimento;
+    }
+
+    public void setFluxoCaixaInvestimento(BigDecimal fluxoCaixaInvestimento) {
+        this.fluxoCaixaInvestimento = fluxoCaixaInvestimento;
+    }
+
+    public BigDecimal getFluxoCaixaFinanciamento() {
+        return fluxoCaixaFinanciamento;
+    }
+
+    public void setFluxoCaixaFinanciamento(BigDecimal fluxoCaixaFinanciamento) {
+        this.fluxoCaixaFinanciamento = fluxoCaixaFinanciamento;
+    }
+
+    public BigDecimal getCaixaFinal() {
+        return caixaFinal;
+    }
+
+    public void setCaixaFinal(BigDecimal caixaFinal) {
+        this.caixaFinal = caixaFinal;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/HistoricalIndicator.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/HistoricalIndicator.java
@@ -1,0 +1,34 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+public class HistoricalIndicator {
+
+    private String nomeIndicador;
+    private Integer ano;
+    private BigDecimal valor;
+
+    public String getNomeIndicador() {
+        return nomeIndicador;
+    }
+
+    public void setNomeIndicador(String nomeIndicador) {
+        this.nomeIndicador = nomeIndicador;
+    }
+
+    public Integer getAno() {
+        return ano;
+    }
+
+    public void setAno(Integer ano) {
+        this.ano = ano;
+    }
+
+    public BigDecimal getValor() {
+        return valor;
+    }
+
+    public void setValor(BigDecimal valor) {
+        this.valor = valor;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/ParidadeBdr.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/ParidadeBdr.java
@@ -1,0 +1,43 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+public class ParidadeBdr {
+
+    private BigDecimal fatorConversao;
+    private String tickerOriginal;
+    private String bolsaOrigem;
+    private String moedaOrigem;
+
+    public BigDecimal getFatorConversao() {
+        return fatorConversao;
+    }
+
+    public void setFatorConversao(BigDecimal fatorConversao) {
+        this.fatorConversao = fatorConversao;
+    }
+
+    public String getTickerOriginal() {
+        return tickerOriginal;
+    }
+
+    public void setTickerOriginal(String tickerOriginal) {
+        this.tickerOriginal = tickerOriginal;
+    }
+
+    public String getBolsaOrigem() {
+        return bolsaOrigem;
+    }
+
+    public void setBolsaOrigem(String bolsaOrigem) {
+        this.bolsaOrigem = bolsaOrigem;
+    }
+
+    public String getMoedaOrigem() {
+        return moedaOrigem;
+    }
+
+    public void setMoedaOrigem(String moedaOrigem) {
+        this.moedaOrigem = moedaOrigem;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/PricePoint.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/PricePoint.java
@@ -1,0 +1,62 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public class PricePoint {
+
+    private Instant timestamp;
+    private BigDecimal openPrice;
+    private BigDecimal highPrice;
+    private BigDecimal lowPrice;
+    private BigDecimal closePrice;
+    private BigDecimal volume;
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public BigDecimal getOpenPrice() {
+        return openPrice;
+    }
+
+    public void setOpenPrice(BigDecimal openPrice) {
+        this.openPrice = openPrice;
+    }
+
+    public BigDecimal getHighPrice() {
+        return highPrice;
+    }
+
+    public void setHighPrice(BigDecimal highPrice) {
+        this.highPrice = highPrice;
+    }
+
+    public BigDecimal getLowPrice() {
+        return lowPrice;
+    }
+
+    public void setLowPrice(BigDecimal lowPrice) {
+        this.lowPrice = lowPrice;
+    }
+
+    public BigDecimal getClosePrice() {
+        return closePrice;
+    }
+
+    public void setClosePrice(BigDecimal closePrice) {
+        this.closePrice = closePrice;
+    }
+
+    public BigDecimal getVolume() {
+        return volume;
+    }
+
+    public void setVolume(BigDecimal volume) {
+        this.volume = volume;
+    }
+}


### PR DESCRIPTION
## Summary
- add BDR domain model with nested financial aggregates and raw JSON metadata
- implement JPA entities, mappers, and repository adapter for persisting BDR aggregates, including JSONB columns and pagination helpers

