### PR TITLE
Refatora scraping de BDR em parsers e coletor dedicados

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/BdrPlaywrightScraperAdapter.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/BdrPlaywrightScraperAdapter.java
@@ -6,9 +6,13 @@ import br.dev.rodrigopinheiro.tickerscraper.infrastructure.parser.IndicadorParse
 import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.PlaywrightInitializer;
 import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.base.AbstractScraperAdapter;
 import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.*;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.network.BdrNetworkPayloadCollector;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.network.BdrNetworkPayloadDTO;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.parser.BdrCotacoesParser;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.parser.BdrDemonstrativosParser;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.parser.BdrDividendosParser;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.parser.BdrIndicadoresParser;
 import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.common.CorrelationIdProvider;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.Page;
@@ -24,24 +28,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.*;
 
@@ -58,19 +52,28 @@ public class BdrPlaywrightScraperAdapter extends AbstractScraperAdapter<BdrDados
     private static final String[] ESSENTIAL_SELECTORS = {"main", "div.container", "section.bdr-header"};
     private static final String[] CARDS_SELECTORS = {"section#cards-ticker", "section.cards", "div.cards"};
 
-    private static final Pattern INVESTIDOR_ID_PATTERN = Pattern.compile("/chart/(\\d+)/");
-    private static final Pattern BALANCO_TIPO_PATTERN = Pattern.compile("/balancos/(\\d+)/(DRE|BP|FC)/", Pattern.CASE_INSENSITIVE);
-
     private final PlaywrightInitializer playwrightInitializer;
     private final CorrelationIdProvider correlationIdProvider;
-    private final ObjectMapper objectMapper;
+    private final BdrNetworkPayloadCollector networkPayloadCollector;
+    private final BdrCotacoesParser cotacoesParser;
+    private final BdrDividendosParser dividendosParser;
+    private final BdrIndicadoresParser indicadoresParser;
+    private final BdrDemonstrativosParser demonstrativosParser;
 
     public BdrPlaywrightScraperAdapter(PlaywrightInitializer playwrightInitializer,
                                        CorrelationIdProvider correlationIdProvider,
-                                       ObjectMapper objectMapper) {
+                                       BdrNetworkPayloadCollector networkPayloadCollector,
+                                       BdrCotacoesParser cotacoesParser,
+                                       BdrDividendosParser dividendosParser,
+                                       BdrIndicadoresParser indicadoresParser,
+                                       BdrDemonstrativosParser demonstrativosParser) {
         this.playwrightInitializer = playwrightInitializer;
         this.correlationIdProvider = correlationIdProvider;
-        this.objectMapper = objectMapper;
+        this.networkPayloadCollector = networkPayloadCollector;
+        this.cotacoesParser = cotacoesParser;
+        this.dividendosParser = dividendosParser;
+        this.indicadoresParser = indicadoresParser;
+        this.demonstrativosParser = demonstrativosParser;
     }
 
     @Override
@@ -93,10 +96,7 @@ public class BdrPlaywrightScraperAdapter extends AbstractScraperAdapter<BdrDados
             ctxRef.set(context);
             pageRef.set(page);
 
-            Map<String, String> payloads = new ConcurrentHashMap<>();
-            AtomicReference<String> investidorId = new AtomicReference<>();
-
-            page.onResponse(response -> handleResponse(response, payloads, investidorId));
+            BdrNetworkPayloadCollector.CaptureSession captureSession = networkPayloadCollector.start(page);
 
             String correlationId = correlationIdProvider.getCurrentCorrelationIdOrDefault("unknown");
 
@@ -107,19 +107,18 @@ public class BdrPlaywrightScraperAdapter extends AbstractScraperAdapter<BdrDados
 
             page.waitForLoadState(LoadState.NETWORKIDLE);
 
-            waitForPayload(payloads, KEY_COTACOES, normalizedTicker, correlationId);
-            waitForPayload(payloads, KEY_DIVIDENDOS, normalizedTicker, correlationId);
-            waitForPayload(payloads, KEY_INDICADORES, normalizedTicker, correlationId);
-            waitForPayload(payloads, KEY_DRE, normalizedTicker, correlationId);
-            waitForPayload(payloads, KEY_BP, normalizedTicker, correlationId);
-            waitForPayload(payloads, KEY_FC, normalizedTicker, correlationId);
+            BdrNetworkPayloadDTO networkPayload = networkPayloadCollector.awaitAndCollect(
+                    captureSession,
+                    normalizedTicker,
+                    correlationId
+            );
 
             String html = page.content();
             Document document = Jsoup.parse(html);
             validateEssentialElements(document, getEssentialSelectors(), getCardsSelectors(), normalizedTicker, url);
 
             BdrHtmlMetadataDTO metadata = extractMetadata(document, html);
-            BdrIndicadoresDTO indicadores = parseIndicadores(payloads.get(KEY_INDICADORES));
+            BdrIndicadoresDTO indicadores = indicadoresParser.parse(networkPayload.payloads().get(KEY_INDICADORES));
 
             // Se não houver paridade nas APIs, tenta extrair do HTML
             if (indicadores.paridade() == null) {
@@ -135,19 +134,19 @@ public class BdrPlaywrightScraperAdapter extends AbstractScraperAdapter<BdrDados
                 );
             }
 
-            BdrCotacoesDTO cotacoes = parseCotacoes(payloads.get(KEY_COTACOES));
-            BdrDividendosDTO dividendos = parseDividendos(payloads.get(KEY_DIVIDENDOS));
-            BdrDemonstrativoDTO dre = parseDemonstrativo(payloads.get(KEY_DRE), "DRE");
-            BdrDemonstrativoDTO bp = parseDemonstrativo(payloads.get(KEY_BP), "BP");
-            BdrDemonstrativoDTO fc = parseDemonstrativo(payloads.get(KEY_FC), "FC");
+            BdrCotacoesDTO cotacoes = cotacoesParser.parse(networkPayload.payloads().get(KEY_COTACOES));
+            BdrDividendosDTO dividendos = dividendosParser.parse(networkPayload.payloads().get(KEY_DIVIDENDOS));
+            BdrDemonstrativoDTO dre = demonstrativosParser.parse(networkPayload.payloads().get(KEY_DRE), "DRE");
+            BdrDemonstrativoDTO bp = demonstrativosParser.parse(networkPayload.payloads().get(KEY_BP), "BP");
+            BdrDemonstrativoDTO fc = demonstrativosParser.parse(networkPayload.payloads().get(KEY_FC), "FC");
 
-            Map<String, String> rawJson = buildRawJson(payloads);
+            Map<String, String> rawJson = buildRawJson(networkPayload.payloads());
 
             Instant updatedAt = Instant.now(Clock.systemUTC());
 
             return new BdrDadosFinanceirosDTO(
                     normalizedTicker,
-                    investidorId.get(),
+                    networkPayload.investidorId(),
                     cotacoes,
                     dividendos,
                     indicadores,
@@ -206,84 +205,6 @@ public class BdrPlaywrightScraperAdapter extends AbstractScraperAdapter<BdrDados
         }, normalizedTicker, () -> {});
     }
 
-    private void handleResponse(Response response,
-                                 Map<String, String> payloads,
-                                 AtomicReference<String> investidorId) {
-        String url = response.url();
-        try {
-            if (url.contains(COTACOES_CHART_PATH) && payloads.putIfAbsent(KEY_COTACOES, response.text()) == null) {
-                extractInvestidorId(url).ifPresent(id -> investidorId.compareAndSet(null, id));
-                logger.debug("Capturada API de cotações: {}", url);
-            } else if (url.contains(DIVIDENDOS_PATH) && payloads.putIfAbsent(KEY_DIVIDENDOS, response.text()) == null) {
-                extractInvestidorId(url).ifPresent(id -> investidorId.compareAndSet(null, id));
-                logger.debug("Capturada API de dividendos: {}", url);
-            } else if (url.contains(HISTORICO_INDICADORES_PATH) &&
-                    payloads.putIfAbsent(KEY_INDICADORES, response.text()) == null) {
-                extractInvestidorId(url).ifPresent(id -> investidorId.compareAndSet(null, id));
-                logger.debug("Capturada API de indicadores: {}", url);
-            } else if (url.contains(BALANCO_DRE_PATH)) {
-                Matcher matcher = BALANCO_TIPO_PATTERN.matcher(url);
-                if (matcher.find()) {
-                    String id = matcher.group(1);
-                    String tipo = matcher.group(2).toUpperCase();
-                    extractInvestidorId(id).ifPresent(value -> investidorId.compareAndSet(null, value));
-                    switch (tipo) {
-                        case "DRE" -> {
-                            if (payloads.putIfAbsent(KEY_DRE, response.text()) == null) {
-                                logger.debug("Capturada API de DRE: {}", url);
-                            }
-                        }
-                        case "BP" -> {
-                            if (payloads.putIfAbsent(KEY_BP, response.text()) == null) {
-                                logger.debug("Capturada API de BP: {}", url);
-                            }
-                        }
-                        case "FC" -> {
-                            if (payloads.putIfAbsent(KEY_FC, response.text()) == null) {
-                                logger.debug("Capturada API de FC: {}", url);
-                            }
-                        }
-                        default -> {
-                        }
-                    }
-                }
-            }
-        } catch (Exception ex) {
-            logger.warn("Falha ao processar resposta {}: {}", url, ex.getMessage());
-        }
-    }
-
-    private Optional<String> extractInvestidorId(String value) {
-        if (value == null) {
-            return Optional.empty();
-        }
-        Matcher matcher = INVESTIDOR_ID_PATTERN.matcher(value);
-        if (matcher.find()) {
-            return Optional.ofNullable(matcher.group(1));
-        }
-        if (value.matches("\\d+")) {
-            return Optional.of(value);
-        }
-        return Optional.empty();
-    }
-
-    private void waitForPayload(Map<String, String> payloads, String key, String ticker, String correlationId) {
-        int waited = 0;
-        int step = 200;
-        while (!payloads.containsKey(key) && waited < NETWORK_CAPTURE_TIMEOUT_MS) {
-            try {
-                Thread.sleep(step);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return;
-            }
-            waited += step;
-        }
-        if (!payloads.containsKey(key)) {
-            logger.warn("Timeout aguardando payload '{}' para {} (correlationId={})", key, ticker, correlationId);
-        }
-    }
-
     private BdrHtmlMetadataDTO extractMetadata(Document document, String html) {
         String title = document.title();
         String description = Optional.ofNullable(document.selectFirst("meta[name=description]")).map(e -> e.attr("content")).orElse(null);
@@ -309,249 +230,6 @@ public class BdrPlaywrightScraperAdapter extends AbstractScraperAdapter<BdrDados
             return IndicadorParser.parseParidadeBdr(raw);
         }
         return Optional.empty();
-    }
-
-    private BdrCotacoesDTO parseCotacoes(String json) {
-        if (json == null || json.isBlank()) {
-            return BdrCotacoesDTO.empty();
-        }
-        try {
-            JsonNode root = objectMapper.readTree(json);
-            JsonNode dataNode = root.has("data") ? root.get("data") : root;
-            if (!dataNode.isArray()) {
-                dataNode = root;
-            }
-            List<BdrPricePointDTO> pontos = new ArrayList<>();
-            for (JsonNode node : dataNode) {
-                Instant timestamp = parseInstant(node);
-                BigDecimal valor = parseValor(node);
-                if (valor != null) {
-                    pontos.add(new BdrPricePointDTO(timestamp, valor));
-                }
-            }
-            if (pontos.size() > 365) {
-                pontos = pontos.subList(Math.max(0, pontos.size() - 365), pontos.size());
-            }
-            String moeda = Optional.ofNullable(root.get("currency"))
-                    .filter(JsonNode::isTextual)
-                    .map(JsonNode::asText)
-                    .orElseGet(() -> IndicadorParser.extrairMoeda(json).orElse(null));
-            return new BdrCotacoesDTO(List.copyOf(pontos), moeda, root);
-        } catch (Exception ex) {
-            logger.warn("Erro ao parsear cotações de BDR: {}", ex.getMessage());
-            return BdrCotacoesDTO.empty();
-        }
-    }
-
-    private Instant parseInstant(JsonNode node) {
-        if (node == null) {
-            return null;
-        }
-        JsonNode valueNode = node.isArray() && node.size() > 0 ? node.get(0) : node.get("date");
-        if (valueNode == null) {
-            valueNode = node.get("x");
-        }
-        if (valueNode == null) {
-            valueNode = node.get("timestamp");
-        }
-        if (valueNode == null) {
-            return null;
-        }
-        if (valueNode.isNumber()) {
-            long epoch = valueNode.asLong();
-            if (String.valueOf(epoch).length() == 13) {
-                return Instant.ofEpochMilli(epoch);
-            }
-            return Instant.ofEpochSecond(epoch);
-        }
-        if (valueNode.isTextual()) {
-            String text = valueNode.asText();
-            try {
-                return Instant.parse(text);
-            } catch (DateTimeParseException ex) {
-                try {
-                    LocalDate date = LocalDate.parse(text, DateTimeFormatter.ISO_LOCAL_DATE);
-                    return date.atStartOfDay(ZoneOffset.UTC).toInstant();
-                } catch (Exception ignored) {
-                    try {
-                        LocalDateTime dateTime = LocalDateTime.parse(text, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-                        return dateTime.atZone(ZoneOffset.UTC).toInstant();
-                    } catch (Exception ignoredAgain) {
-                        logger.debug("Formato de data não suportado para valor '{}': {}", text, ignoredAgain.getMessage());
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    private BigDecimal parseValor(JsonNode node) {
-        JsonNode valueNode = node.isArray() && node.size() > 1 ? node.get(1) : node.get("value");
-        if (valueNode == null) {
-            valueNode = node.get("y");
-        }
-        if (valueNode == null) {
-            return null;
-        }
-        if (valueNode.isNumber()) {
-            return valueNode.decimalValue();
-        }
-        if (valueNode.isTextual()) {
-            return IndicadorParser.parseValorMonetario(valueNode.asText()).orElse(null);
-        }
-        return null;
-    }
-
-    private BdrDividendosDTO parseDividendos(String json) {
-        if (json == null || json.isBlank()) {
-            return BdrDividendosDTO.empty();
-        }
-        try {
-            JsonNode root = objectMapper.readTree(json);
-            JsonNode dataNode = root.has("data") ? root.get("data") : root;
-            if (!dataNode.isArray()) {
-                dataNode = root;
-            }
-            List<BdrDividendoItemDTO> itens = new ArrayList<>();
-            for (JsonNode item : dataNode) {
-                String periodo = Optional.ofNullable(item.get("periodo"))
-                        .filter(JsonNode::isTextual)
-                        .map(JsonNode::asText)
-                        .orElseGet(() -> Optional.ofNullable(item.get("label"))
-                                .filter(JsonNode::isTextual)
-                                .map(JsonNode::asText)
-                                .orElse(null));
-                BigDecimal valor = null;
-                if (item.has("valor")) {
-                    valor = IndicadorParser.parseValorMonetario(item.get("valor").asText()).orElse(null);
-                } else if (item.has("value")) {
-                    JsonNode valueNode = item.get("value");
-                    if (valueNode.isNumber()) {
-                        valor = valueNode.decimalValue();
-                    } else if (valueNode.isTextual()) {
-                        valor = IndicadorParser.parseValorMonetario(valueNode.asText()).orElse(null);
-                    }
-                }
-                String moeda = null;
-                if (item.has("valor")) {
-                    moeda = IndicadorParser.extrairMoeda(item.get("valor").asText()).orElse(null);
-                }
-                if (valor != null) {
-                    itens.add(new BdrDividendoItemDTO(periodo, valor, moeda));
-                }
-            }
-            if (itens.size() > 5) {
-                itens = itens.subList(Math.max(0, itens.size() - 5), itens.size());
-            }
-            return new BdrDividendosDTO(List.copyOf(itens), root);
-        } catch (Exception ex) {
-            logger.warn("Erro ao parsear dividendos de BDR: {}", ex.getMessage());
-            return BdrDividendosDTO.empty();
-        }
-    }
-
-    private BdrIndicadoresDTO parseIndicadores(String json) {
-        if (json == null || json.isBlank()) {
-            return BdrIndicadoresDTO.empty();
-        }
-        try {
-            JsonNode root = objectMapper.readTree(json);
-            Map<String, BigDecimal> monetarios = new LinkedHashMap<>();
-            Map<String, BigDecimal> percentuais = new LinkedHashMap<>();
-            Map<String, Double> simples = new LinkedHashMap<>();
-            String moedaPadrao = null;
-            IndicadorParser.ParidadeBdrInfo paridade = null;
-
-            if (root.isArray()) {
-                for (JsonNode node : root) {
-                    processIndicatorNode(node, monetarios, percentuais, simples);
-                    if (moedaPadrao == null && node.has("valor")) {
-                        moedaPadrao = IndicadorParser.extrairMoeda(node.get("valor").asText()).orElse(null);
-                    }
-                    if (paridade == null && node.has("valor")) {
-                        paridade = IndicadorParser.parseParidadeBdr(node.get("valor").asText()).orElse(null);
-                    }
-                }
-            } else if (root.isObject()) {
-                root.fields().forEachRemaining(entry -> {
-                    JsonNode value = entry.getValue();
-                    if (value.isTextual()) {
-                        String texto = value.asText();
-                        IndicadorParser.parseValorMonetario(texto)
-                                .ifPresent(valor -> monetarios.put(entry.getKey(), valor));
-                        IndicadorParser.parsePercentualParaDecimal(texto)
-                                .ifPresent(p -> percentuais.put(entry.getKey(), p));
-                        IndicadorParser.safeParseDouble(texto)
-                                .ifPresent(v -> simples.put(entry.getKey(), v));
-                        if (moedaPadrao == null) {
-                            moedaPadrao = IndicadorParser.extrairMoeda(texto).orElse(null);
-                        }
-                        if (paridade == null) {
-                            paridade = IndicadorParser.parseParidadeBdr(texto).orElse(null);
-                        }
-                    } else if (value.isNumber()) {
-                        simples.put(entry.getKey(), value.doubleValue());
-                    }
-                });
-            }
-
-            return new BdrIndicadoresDTO(monetarios, percentuais, simples, paridade, moedaPadrao, root);
-        } catch (Exception ex) {
-            logger.warn("Erro ao parsear indicadores de BDR: {}", ex.getMessage());
-            return BdrIndicadoresDTO.empty();
-        }
-    }
-
-    private void processIndicatorNode(JsonNode node,
-                                      Map<String, BigDecimal> monetarios,
-                                      Map<String, BigDecimal> percentuais,
-                                      Map<String, Double> simples) {
-        String nome = Optional.ofNullable(node.get("nome"))
-                .filter(JsonNode::isTextual)
-                .map(JsonNode::asText)
-                .orElse(null);
-        JsonNode valorNode = node.get("valor");
-        if (valorNode == null && node.has("value")) {
-            valorNode = node.get("value");
-        }
-        if (valorNode == null) {
-            return;
-        }
-        if (valorNode.isNumber()) {
-            simples.put(nome, valorNode.doubleValue());
-            return;
-        }
-        if (valorNode.isTextual()) {
-            String texto = valorNode.asText();
-            IndicadorParser.parseValorMonetario(texto).ifPresent(valor -> {
-                if (nome != null) {
-                    monetarios.put(nome, valor);
-                }
-            });
-            IndicadorParser.parsePercentualParaDecimal(texto).ifPresent(valor -> {
-                if (nome != null) {
-                    percentuais.put(nome, valor);
-                }
-            });
-            IndicadorParser.safeParseDouble(texto).ifPresent(valor -> {
-                if (nome != null) {
-                    simples.put(nome, valor);
-                }
-            });
-        }
-    }
-
-    private BdrDemonstrativoDTO parseDemonstrativo(String json, String tipo) {
-        if (json == null || json.isBlank()) {
-            return BdrDemonstrativoDTO.empty(tipo);
-        }
-        try {
-            JsonNode root = objectMapper.readTree(json);
-            return new BdrDemonstrativoDTO(tipo, root);
-        } catch (Exception ex) {
-            logger.warn("Erro ao parsear demonstrativo {} de BDR: {}", tipo, ex.getMessage());
-            return BdrDemonstrativoDTO.empty(tipo);
-        }
     }
 
     private Map<String, String> buildRawJson(Map<String, String> payloads) {

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/network/BdrNetworkPayloadCollector.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/network/BdrNetworkPayloadCollector.java
@@ -1,0 +1,133 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.network;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.BALANCO_DRE_PATH;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.COTACOES_CHART_PATH;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.DIVIDENDOS_PATH;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.HISTORICO_INDICADORES_PATH;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.KEY_BP;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.KEY_COTACOES;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.KEY_DIVIDENDOS;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.KEY_DRE;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.KEY_FC;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrApiConstants.KEY_INDICADORES;
+import static br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.BdrScraperConstants.NETWORK_CAPTURE_TIMEOUT_MS;
+
+/**
+ * Encapsula a configuração dos listeners de rede do Playwright e aguarda os payloads essenciais.
+ */
+@Component
+public class BdrNetworkPayloadCollector {
+
+    private static final Logger logger = LoggerFactory.getLogger(BdrNetworkPayloadCollector.class);
+
+    private static final Pattern INVESTIDOR_ID_PATTERN = Pattern.compile("/chart/(\\d+)/");
+    private static final Pattern BALANCO_TIPO_PATTERN = Pattern.compile("/balancos/(\\d+)/(DRE|BP|FC)/", Pattern.CASE_INSENSITIVE);
+
+    public CaptureSession start(Page page) {
+        ConcurrentHashMap<String, String> payloads = new ConcurrentHashMap<>();
+        AtomicReference<String> investidorId = new AtomicReference<>();
+        page.onResponse(response -> handleResponse(response, payloads, investidorId));
+        return new CaptureSession(payloads, investidorId);
+    }
+
+    public BdrNetworkPayloadDTO awaitAndCollect(CaptureSession session, String ticker, String correlationId) {
+        for (String key : new String[]{KEY_COTACOES, KEY_DIVIDENDOS, KEY_INDICADORES, KEY_DRE, KEY_BP, KEY_FC}) {
+            waitForPayload(session.payloads(), key, ticker, correlationId);
+        }
+        return new BdrNetworkPayloadDTO(session.investidorId().get(), Map.copyOf(session.payloads()));
+    }
+
+    private void handleResponse(Response response,
+                                 Map<String, String> payloads,
+                                 AtomicReference<String> investidorId) {
+        String url = response.url();
+        try {
+            if (url.contains(COTACOES_CHART_PATH) && payloads.putIfAbsent(KEY_COTACOES, response.text()) == null) {
+                extractInvestidorId(url).ifPresent(id -> investidorId.compareAndSet(null, id));
+                logger.debug("Capturada API de cotações: {}", url);
+            } else if (url.contains(DIVIDENDOS_PATH) && payloads.putIfAbsent(KEY_DIVIDENDOS, response.text()) == null) {
+                extractInvestidorId(url).ifPresent(id -> investidorId.compareAndSet(null, id));
+                logger.debug("Capturada API de dividendos: {}", url);
+            } else if (url.contains(HISTORICO_INDICADORES_PATH) &&
+                    payloads.putIfAbsent(KEY_INDICADORES, response.text()) == null) {
+                extractInvestidorId(url).ifPresent(id -> investidorId.compareAndSet(null, id));
+                logger.debug("Capturada API de indicadores: {}", url);
+            } else if (url.contains(BALANCO_DRE_PATH)) {
+                Matcher matcher = BALANCO_TIPO_PATTERN.matcher(url);
+                if (matcher.find()) {
+                    String id = matcher.group(1);
+                    String tipo = matcher.group(2).toUpperCase();
+                    extractInvestidorId(id).ifPresent(value -> investidorId.compareAndSet(null, value));
+                    switch (tipo) {
+                        case "DRE" -> {
+                            if (payloads.putIfAbsent(KEY_DRE, response.text()) == null) {
+                                logger.debug("Capturada API de DRE: {}", url);
+                            }
+                        }
+                        case "BP" -> {
+                            if (payloads.putIfAbsent(KEY_BP, response.text()) == null) {
+                                logger.debug("Capturada API de BP: {}", url);
+                            }
+                        }
+                        case "FC" -> {
+                            if (payloads.putIfAbsent(KEY_FC, response.text()) == null) {
+                                logger.debug("Capturada API de FC: {}", url);
+                            }
+                        }
+                        default -> {
+                        }
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            logger.warn("Falha ao processar resposta {}: {}", url, ex.getMessage());
+        }
+    }
+
+    private Optional<String> extractInvestidorId(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        Matcher matcher = INVESTIDOR_ID_PATTERN.matcher(value);
+        if (matcher.find()) {
+            return Optional.ofNullable(matcher.group(1));
+        }
+        if (value.matches("\\d+")) {
+            return Optional.of(value);
+        }
+        return Optional.empty();
+    }
+
+    private void waitForPayload(Map<String, String> payloads, String key, String ticker, String correlationId) {
+        int waited = 0;
+        int step = 200;
+        while (!payloads.containsKey(key) && waited < NETWORK_CAPTURE_TIMEOUT_MS) {
+            try {
+                Thread.sleep(step);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            waited += step;
+        }
+        if (!payloads.containsKey(key)) {
+            logger.warn("Timeout aguardando payload '{}' para {} (correlationId={})", key, ticker, correlationId);
+        }
+    }
+
+    public record CaptureSession(Map<String, String> payloads, AtomicReference<String> investidorId) {
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/network/BdrNetworkPayloadDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/network/BdrNetworkPayloadDTO.java
@@ -1,0 +1,9 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.network;
+
+import java.util.Map;
+
+/**
+ * Resultado da captura de rede contendo o investidorId e os payloads crus das APIs.
+ */
+public record BdrNetworkPayloadDTO(String investidorId, Map<String, String> payloads) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/parser/BdrCotacoesParser.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/parser/BdrCotacoesParser.java
@@ -1,0 +1,127 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.parser;
+
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.parser.IndicadorParser;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.BdrCotacoesDTO;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.BdrPricePointDTO;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Responsável por converter o payload bruto de cotações em um {@link BdrCotacoesDTO}.
+ */
+@Component
+public class BdrCotacoesParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(BdrCotacoesParser.class);
+
+    private final ObjectMapper objectMapper;
+
+    public BdrCotacoesParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public BdrCotacoesDTO parse(String json) {
+        if (json == null || json.isBlank()) {
+            return BdrCotacoesDTO.empty();
+        }
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            JsonNode dataNode = root.has("data") ? root.get("data") : root;
+            if (!dataNode.isArray()) {
+                dataNode = root;
+            }
+            List<BdrPricePointDTO> pontos = new ArrayList<>();
+            for (JsonNode node : dataNode) {
+                Instant timestamp = parseInstant(node);
+                BigDecimal valor = parseValor(node);
+                if (valor != null) {
+                    pontos.add(new BdrPricePointDTO(timestamp, valor));
+                }
+            }
+            if (pontos.size() > 365) {
+                pontos = pontos.subList(Math.max(0, pontos.size() - 365), pontos.size());
+            }
+            String moeda = Optional.ofNullable(root.get("currency"))
+                    .filter(JsonNode::isTextual)
+                    .map(JsonNode::asText)
+                    .orElseGet(() -> IndicadorParser.extrairMoeda(json).orElse(null));
+            return new BdrCotacoesDTO(List.copyOf(pontos), moeda, root);
+        } catch (Exception ex) {
+            logger.warn("Erro ao parsear cotações de BDR: {}", ex.getMessage());
+            return BdrCotacoesDTO.empty();
+        }
+    }
+
+    private Instant parseInstant(JsonNode node) {
+        if (node == null) {
+            return null;
+        }
+        JsonNode valueNode = node.isArray() && node.size() > 0 ? node.get(0) : node.get("date");
+        if (valueNode == null) {
+            valueNode = node.get("x");
+        }
+        if (valueNode == null) {
+            valueNode = node.get("timestamp");
+        }
+        if (valueNode == null) {
+            return null;
+        }
+        if (valueNode.isNumber()) {
+            long epoch = valueNode.asLong();
+            if (String.valueOf(epoch).length() == 13) {
+                return Instant.ofEpochMilli(epoch);
+            }
+            return Instant.ofEpochSecond(epoch);
+        }
+        if (valueNode.isTextual()) {
+            String text = valueNode.asText();
+            try {
+                return Instant.parse(text);
+            } catch (DateTimeParseException ex) {
+                try {
+                    LocalDate date = LocalDate.parse(text, DateTimeFormatter.ISO_LOCAL_DATE);
+                    return date.atStartOfDay(ZoneOffset.UTC).toInstant();
+                } catch (Exception ignored) {
+                    try {
+                        LocalDateTime dateTime = LocalDateTime.parse(text, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+                        return dateTime.atZone(ZoneOffset.UTC).toInstant();
+                    } catch (Exception ignoredAgain) {
+                        logger.debug("Formato de data não suportado para valor '{}': {}", text, ignoredAgain.getMessage());
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private BigDecimal parseValor(JsonNode node) {
+        JsonNode valueNode = node.isArray() && node.size() > 1 ? node.get(1) : node.get("value");
+        if (valueNode == null) {
+            valueNode = node.get("y");
+        }
+        if (valueNode == null) {
+            return null;
+        }
+        if (valueNode.isNumber()) {
+            return valueNode.decimalValue();
+        }
+        if (valueNode.isTextual()) {
+            return IndicadorParser.parseValorMonetario(valueNode.asText()).orElse(null);
+        }
+        return null;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/parser/BdrDemonstrativosParser.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/parser/BdrDemonstrativosParser.java
@@ -1,0 +1,36 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.parser;
+
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.BdrDemonstrativoDTO;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converte os payloads dos demonstrativos financeiros (DRE, BP, FC).
+ */
+@Component
+public class BdrDemonstrativosParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(BdrDemonstrativosParser.class);
+
+    private final ObjectMapper objectMapper;
+
+    public BdrDemonstrativosParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public BdrDemonstrativoDTO parse(String json, String tipo) {
+        if (json == null || json.isBlank()) {
+            return BdrDemonstrativoDTO.empty(tipo);
+        }
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            return new BdrDemonstrativoDTO(tipo, root);
+        } catch (Exception ex) {
+            logger.warn("Erro ao parsear demonstrativo {} de BDR: {}", tipo, ex.getMessage());
+            return BdrDemonstrativoDTO.empty(tipo);
+        }
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/parser/BdrDividendosParser.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/parser/BdrDividendosParser.java
@@ -1,0 +1,84 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.parser;
+
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.parser.IndicadorParser;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.BdrDividendosDTO;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.BdrDividendoItemDTO;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Converte os payloads de dividendos em {@link BdrDividendosDTO}.
+ */
+@Component
+public class BdrDividendosParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(BdrDividendosParser.class);
+
+    private final ObjectMapper objectMapper;
+
+    public BdrDividendosParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public BdrDividendosDTO parse(String json) {
+        if (json == null || json.isBlank()) {
+            return BdrDividendosDTO.empty();
+        }
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            JsonNode dataNode = root.has("data") ? root.get("data") : root;
+            if (!dataNode.isArray()) {
+                dataNode = root;
+            }
+            List<BdrDividendoItemDTO> itens = new ArrayList<>();
+            for (JsonNode item : dataNode) {
+                String periodo = Optional.ofNullable(item.get("periodo"))
+                        .filter(JsonNode::isTextual)
+                        .map(JsonNode::asText)
+                        .orElseGet(() -> Optional.ofNullable(item.get("label"))
+                                .filter(JsonNode::isTextual)
+                                .map(JsonNode::asText)
+                                .orElse(null));
+                BigDecimal valor = parseValor(item);
+                String moeda = null;
+                if (item.has("valor")) {
+                    moeda = IndicadorParser.extrairMoeda(item.get("valor").asText()).orElse(null);
+                }
+                if (valor != null) {
+                    itens.add(new BdrDividendoItemDTO(periodo, valor, moeda));
+                }
+            }
+            if (itens.size() > 5) {
+                itens = itens.subList(Math.max(0, itens.size() - 5), itens.size());
+            }
+            return new BdrDividendosDTO(List.copyOf(itens), root);
+        } catch (Exception ex) {
+            logger.warn("Erro ao parsear dividendos de BDR: {}", ex.getMessage());
+            return BdrDividendosDTO.empty();
+        }
+    }
+
+    private BigDecimal parseValor(JsonNode item) {
+        if (item.has("valor")) {
+            return IndicadorParser.parseValorMonetario(item.get("valor").asText()).orElse(null);
+        }
+        if (item.has("value")) {
+            JsonNode valueNode = item.get("value");
+            if (valueNode.isNumber()) {
+                return valueNode.decimalValue();
+            }
+            if (valueNode.isTextual()) {
+                return IndicadorParser.parseValorMonetario(valueNode.asText()).orElse(null);
+            }
+        }
+        return null;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/parser/BdrIndicadoresParser.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/parser/BdrIndicadoresParser.java
@@ -1,0 +1,120 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.parser;
+
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.parser.IndicadorParser;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.BdrIndicadoresDTO;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Parser responsável por consolidar os indicadores financeiros do BDR.
+ */
+@Component
+public class BdrIndicadoresParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(BdrIndicadoresParser.class);
+
+    private final ObjectMapper objectMapper;
+
+    public BdrIndicadoresParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public BdrIndicadoresDTO parse(String json) {
+        if (json == null || json.isBlank()) {
+            return BdrIndicadoresDTO.empty();
+        }
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            Map<String, BigDecimal> monetarios = new LinkedHashMap<>();
+            Map<String, BigDecimal> percentuais = new LinkedHashMap<>();
+            Map<String, Double> simples = new LinkedHashMap<>();
+            String moedaPadrao = null;
+            IndicadorParser.ParidadeBdrInfo paridade = null;
+
+            if (root.isArray()) {
+                for (JsonNode node : root) {
+                    processIndicatorNode(node, monetarios, percentuais, simples);
+                    if (moedaPadrao == null && node.has("valor")) {
+                        moedaPadrao = IndicadorParser.extrairMoeda(node.get("valor").asText()).orElse(null);
+                    }
+                    if (paridade == null && node.has("valor")) {
+                        paridade = IndicadorParser.parseParidadeBdr(node.get("valor").asText()).orElse(null);
+                    }
+                }
+            } else if (root.isObject()) {
+                root.fields().forEachRemaining(entry -> {
+                    JsonNode value = entry.getValue();
+                    if (value.isTextual()) {
+                        String texto = value.asText();
+                        IndicadorParser.parseValorMonetario(texto)
+                                .ifPresent(valor -> monetarios.put(entry.getKey(), valor));
+                        IndicadorParser.parsePercentualParaDecimal(texto)
+                                .ifPresent(p -> percentuais.put(entry.getKey(), p));
+                        IndicadorParser.safeParseDouble(texto)
+                                .ifPresent(v -> simples.put(entry.getKey(), v));
+                        if (moedaPadrao == null) {
+                            moedaPadrao = IndicadorParser.extrairMoeda(texto).orElse(null);
+                        }
+                        if (paridade == null) {
+                            paridade = IndicadorParser.parseParidadeBdr(texto).orElse(null);
+                        }
+                    } else if (value.isNumber()) {
+                        simples.put(entry.getKey(), value.doubleValue());
+                    }
+                });
+            }
+
+            return new BdrIndicadoresDTO(monetarios, percentuais, simples, paridade, moedaPadrao, root);
+        } catch (Exception ex) {
+            logger.warn("Erro ao parsear indicadores de BDR: {}", ex.getMessage());
+            return BdrIndicadoresDTO.empty();
+        }
+    }
+
+    private void processIndicatorNode(JsonNode node,
+                                      Map<String, BigDecimal> monetarios,
+                                      Map<String, BigDecimal> percentuais,
+                                      Map<String, Double> simples) {
+        String nome = Optional.ofNullable(node.get("nome"))
+                .filter(JsonNode::isTextual)
+                .map(JsonNode::asText)
+                .orElse(null);
+        JsonNode valorNode = node.get("valor");
+        if (valorNode == null && node.has("value")) {
+            valorNode = node.get("value");
+        }
+        if (valorNode == null) {
+            return;
+        }
+        if (valorNode.isNumber()) {
+            simples.put(nome, valorNode.doubleValue());
+            return;
+        }
+        if (valorNode.isTextual()) {
+            String texto = valorNode.asText();
+            IndicadorParser.parseValorMonetario(texto).ifPresent(valor -> {
+                if (nome != null) {
+                    monetarios.put(nome, valor);
+                }
+            });
+            IndicadorParser.parsePercentualParaDecimal(texto).ifPresent(valor -> {
+                if (nome != null) {
+                    percentuais.put(nome, valor);
+                }
+            });
+            IndicadorParser.safeParseDouble(texto).ifPresent(valor -> {
+                if (nome != null) {
+                    simples.put(nome, valor);
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduz parsers dedicados para cotações, dividendos, indicadores e demonstrativos de BDR utilizando o ObjectMapper existente
- adiciona o helper BdrNetworkPayloadCollector para encapsular a captura dos payloads de rede e retornar um DTO com investidorId
- atualiza o BdrPlaywrightScraperAdapter para delegar parsing e captura de payloads aos novos componentes, focando na orquestração do Playwright

