### PR TITLE
Add full BDR support across pipeline

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/BdrController.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/BdrController.java
@@ -1,0 +1,49 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto.BdrResponseDTO;
+import br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.mapper.BdrApiMapper;
+import br.dev.rodrigopinheiro.tickerscraper.application.dto.BdrRawDataResponse;
+import br.dev.rodrigopinheiro.tickerscraper.application.port.input.BdrUseCasePort;
+import com.github.dockerjava.api.exception.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/bdr")
+public class BdrController {
+
+    private static final Logger log = LoggerFactory.getLogger(BdrController.class);
+
+    private final BdrUseCasePort useCase;
+    private final BdrApiMapper mapper;
+
+    public BdrController(BdrUseCasePort useCase, BdrApiMapper mapper) {
+        this.useCase = useCase;
+        this.mapper = mapper;
+    }
+
+    @GetMapping("/get-{ticker}")
+    public Mono<ResponseEntity<BdrResponseDTO>> get(@PathVariable String ticker) {
+        log.info("GET /bdr/get-{}", ticker);
+        return useCase.getTickerData(ticker)
+                .map(mapper::toResponse)
+                .map(ResponseEntity::ok)
+                .onErrorResume(NotFoundException.class,
+                        error -> Mono.just(ResponseEntity.notFound().build()));
+    }
+
+    @GetMapping("/get-{ticker}/raw")
+    public Mono<ResponseEntity<BdrRawDataResponse>> getRaw(@PathVariable String ticker) {
+        log.info("GET /bdr/get-{}/raw", ticker);
+        return useCase.getRawTickerData(ticker)
+                .map(ResponseEntity::ok)
+                .onErrorResume(NotFoundException.class,
+                        error -> Mono.just(ResponseEntity.notFound().build()));
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/AtivoResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/AtivoResponseDTO.java
@@ -12,18 +12,18 @@ import java.time.LocalDateTime;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AtivoResponseDTO {
-    
+
     private String ticker;
     private TipoAtivoFinanceiroVariavel tipoAtivo;
     private String nomeEmpresa;
     private LocalDateTime dataAtualizacao;
     private ClassificacaoInfo classificacao;
-    
+
     // Dados específicos (apenas um será preenchido)
     private AcaoResponseDTO dadosAcao;
     private FiiResponseDTO dadosFii;
     private EtfResponseDTO dadosEtf;
-    // TODO: Adicionar BdrResponseDTO
+    private BdrResponseDTO dadosBdr;
     
     // Dados financeiros básicos (sempre preenchidos)
     private BigDecimal cotacao;
@@ -105,6 +105,30 @@ public class AtivoResponseDTO {
             .dadosEtf(etfData)
             .cotacao(etfData.valorAtual())
             .variacao(etfData.variacao12M())
+            .classificacao(ClassificacaoInfo.builder()
+                .metodo("BANCO_DADOS")
+                .confianca("ALTA")
+                .build())
+            .build();
+    }
+
+    /**
+     * Factory method para criar resposta de BDR.
+     */
+    public static AtivoResponseDTO fromBdr(String ticker, TipoAtivoFinanceiroVariavel tipo, BdrResponseDTO bdrData) {
+        Long volumeMedio = null;
+        if (bdrData.indicadores() != null && bdrData.indicadores().volumeMedio() != null) {
+            volumeMedio = bdrData.indicadores().volumeMedio().longValue();
+        }
+        return AtivoResponseDTO.builder()
+            .ticker(ticker)
+            .tipoAtivo(tipo)
+            .nomeEmpresa(bdrData.nomeEmpresa() != null ? bdrData.nomeEmpresa() : bdrData.nomeAcaoOriginal())
+            .dataAtualizacao(LocalDateTime.now())
+            .dadosBdr(bdrData)
+            .cotacao(bdrData.precoAtual())
+            .variacaoPercentual(bdrData.variacaoDia())
+            .volume(volumeMedio)
             .classificacao(ClassificacaoInfo.builder()
                 .metodo("BANCO_DADOS")
                 .confianca("ALTA")

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrBpYearResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrBpYearResponseDTO.java
@@ -1,0 +1,13 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+
+public record BdrBpYearResponseDTO(
+        Integer ano,
+        BigDecimal ativosTotais,
+        BigDecimal passivosTotais,
+        BigDecimal patrimonioLiquido,
+        BigDecimal caixaEDisponibilidades,
+        BigDecimal dividaBruta
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrCurrentIndicatorsResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrCurrentIndicatorsResponseDTO.java
@@ -1,0 +1,16 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+
+public record BdrCurrentIndicatorsResponseDTO(
+        BigDecimal ultimoPreco,
+        BigDecimal variacaoPercentualDia,
+        BigDecimal variacaoPercentualMes,
+        BigDecimal variacaoPercentualAno,
+        BigDecimal dividendYield,
+        BigDecimal precoLucro,
+        BigDecimal precoValorPatrimonial,
+        BigDecimal valorMercado,
+        BigDecimal volumeMedio
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDividendYearResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDividendYearResponseDTO.java
@@ -1,0 +1,10 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+
+public record BdrDividendYearResponseDTO(
+        Integer ano,
+        BigDecimal totalDividendo,
+        BigDecimal dividendYield
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDreYearResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDreYearResponseDTO.java
@@ -1,0 +1,13 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+
+public record BdrDreYearResponseDTO(
+        Integer ano,
+        BigDecimal receitaLiquida,
+        BigDecimal lucroLiquido,
+        BigDecimal ebitda,
+        BigDecimal ebit,
+        BigDecimal margemLiquida
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrFcYearResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrFcYearResponseDTO.java
@@ -1,0 +1,12 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+
+public record BdrFcYearResponseDTO(
+        Integer ano,
+        BigDecimal fluxoCaixaOperacional,
+        BigDecimal fluxoCaixaInvestimento,
+        BigDecimal fluxoCaixaFinanciamento,
+        BigDecimal caixaFinal
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrHistoricalIndicatorResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrHistoricalIndicatorResponseDTO.java
@@ -1,0 +1,10 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+
+public record BdrHistoricalIndicatorResponseDTO(
+        String indicador,
+        Integer ano,
+        BigDecimal valor
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrParidadeResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrParidadeResponseDTO.java
@@ -1,0 +1,11 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+
+public record BdrParidadeResponseDTO(
+        BigDecimal fatorConversao,
+        String tickerOriginal,
+        String bolsaOrigem,
+        String moedaOrigem
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrPricePointResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrPricePointResponseDTO.java
@@ -1,0 +1,14 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record BdrPricePointResponseDTO(
+        Instant timestamp,
+        BigDecimal openPrice,
+        BigDecimal highPrice,
+        BigDecimal lowPrice,
+        BigDecimal closePrice,
+        BigDecimal volume
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrResponseDTO.java
@@ -1,0 +1,36 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.TipoAtivo;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record BdrResponseDTO(
+        String ticker,
+        TipoAtivo tipoAtivo,
+        String nomeEmpresa,
+        String nomeAcaoOriginal,
+        String codigoNegociacao,
+        String mercado,
+        String paisDeNegociacao,
+        String moedaDeReferencia,
+        BigDecimal precoAtual,
+        BigDecimal variacaoDia,
+        BigDecimal variacaoMes,
+        BigDecimal variacaoAno,
+        BigDecimal dividendYield,
+        BigDecimal precoAlvo,
+        BdrParidadeResponseDTO paridade,
+        BdrCurrentIndicatorsResponseDTO indicadores,
+        List<BdrPricePointResponseDTO> historicoDePrecos,
+        List<BdrDividendYearResponseDTO> dividendosPorAno,
+        List<BdrHistoricalIndicatorResponseDTO> indicadoresHistoricos,
+        List<BdrDreYearResponseDTO> dreAnual,
+        List<BdrBpYearResponseDTO> balancoPatrimonial,
+        List<BdrFcYearResponseDTO> fluxoDeCaixa,
+        Instant atualizadoEm,
+        Map<String, Object> rawJson
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
@@ -1,0 +1,38 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.mapper;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto.*;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+@Mapper(componentModel = "spring")
+public interface BdrApiMapper {
+
+    @Mappings({
+            @Mapping(source = "historicoDePrecos", target = "historicoDePrecos"),
+            @Mapping(source = "dividendosPorAno", target = "dividendosPorAno"),
+            @Mapping(source = "indicadoresHistoricos", target = "indicadoresHistoricos"),
+            @Mapping(source = "dreAnual", target = "dreAnual"),
+            @Mapping(source = "bpAnual", target = "balancoPatrimonial"),
+            @Mapping(source = "fcAnual", target = "fluxoDeCaixa"),
+            @Mapping(source = "updatedAt", target = "atualizadoEm")
+    })
+    BdrResponseDTO toResponse(Bdr domain);
+
+    BdrParidadeResponseDTO toResponse(ParidadeBdr paridade);
+
+    BdrCurrentIndicatorsResponseDTO toResponse(CurrentIndicators indicators);
+
+    BdrPricePointResponseDTO toResponse(PricePoint pricePoint);
+
+    BdrDividendYearResponseDTO toResponse(DividendYear year);
+
+    BdrHistoricalIndicatorResponseDTO toResponse(HistoricalIndicator indicator);
+
+    BdrDreYearResponseDTO toResponse(DreYear year);
+
+    BdrBpYearResponseDTO toResponse(BpYear year);
+
+    BdrFcYearResponseDTO toResponse(FcYear year);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/dto/BdrRawDataResponse.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/dto/BdrRawDataResponse.java
@@ -1,0 +1,31 @@
+package br.dev.rodrigopinheiro.tickerscraper.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * DTO para transporte de dados brutos de BDRs entre a aplicação e a camada de apresentação.
+ *
+ * @param ticker código do BDR
+ * @param investidorId identificador da sessão na Investidor10 (quando disponível)
+ * @param rawData estrutura com dados já pré-normalizados (cotação, dividendos, indicadores, etc.)
+ * @param apiPayloads payloads capturados das APIs externas durante o scraping
+ * @param source fonte do scraping (playwright, selenium...)
+ * @param scrapingTimestamp timestamp da coleta
+ * @param processingStatus status geral da captura (SUCCESS, PARTIAL, FAILED)
+ * @param metadata metadados adicionais sobre a execução
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BdrRawDataResponse(
+        String ticker,
+        String investidorId,
+        Map<String, Object> rawData,
+        Map<String, String> apiPayloads,
+        String source,
+        LocalDateTime scrapingTimestamp,
+        ProcessingStatus processingStatus,
+        Map<String, String> metadata
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/port/input/BdrUseCasePort.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/port/input/BdrUseCasePort.java
@@ -1,0 +1,30 @@
+package br.dev.rodrigopinheiro.tickerscraper.application.port.input;
+
+import br.dev.rodrigopinheiro.tickerscraper.application.dto.BdrRawDataResponse;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.Bdr;
+import reactor.core.publisher.Mono;
+
+/**
+ * Porta de entrada para operações relacionadas a BDRs.
+ *
+ * <p>Expõe contratos reativos que isolam a camada de aplicação dos
+ * detalhes de infraestrutura (scrapers, repositórios, etc.).</p>
+ */
+public interface BdrUseCasePort {
+
+    /**
+     * Obtém os dados já processados de um BDR a partir do ticker informado.
+     *
+     * @param ticker código do ativo
+     * @return representação de domínio com os dados consolidados
+     */
+    Mono<Bdr> getTickerData(String ticker);
+
+    /**
+     * Obtém os dados brutos coletados no scraping para inspeção/debug.
+     *
+     * @param ticker código do ativo
+     * @return DTO com os dados crus e metadados da coleta
+     */
+    Mono<BdrRawDataResponse> getRawTickerData(String ticker);
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/service/BdrUseCaseService.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/service/BdrUseCaseService.java
@@ -1,0 +1,132 @@
+package br.dev.rodrigopinheiro.tickerscraper.application.service;
+
+import br.dev.rodrigopinheiro.tickerscraper.application.dto.BdrRawDataResponse;
+import br.dev.rodrigopinheiro.tickerscraper.application.mapper.RawDataMapper;
+import br.dev.rodrigopinheiro.tickerscraper.application.port.input.BdrUseCasePort;
+import br.dev.rodrigopinheiro.tickerscraper.application.port.output.BdrDataScrapperPort;
+import br.dev.rodrigopinheiro.tickerscraper.application.port.output.BdrRepositoryPort;
+import br.dev.rodrigopinheiro.tickerscraper.application.service.base.AbstractTickerUseCaseService;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.Bdr;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.BdrDadosFinanceirosDTO;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.mapper.BdrScraperMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class BdrUseCaseService extends AbstractTickerUseCaseService<BdrDadosFinanceirosDTO, Bdr, BdrRawDataResponse>
+        implements BdrUseCasePort {
+
+    private final BdrDataScrapperPort scraper;
+    private final BdrRepositoryPort repository;
+    private final BdrScraperMapper scraperMapper;
+    private final RawDataMapper rawDataMapper;
+
+    public BdrUseCaseService(@Qualifier("bdrPlaywrightScraper") BdrDataScrapperPort scraper,
+                             BdrRepositoryPort repository,
+                             BdrScraperMapper scraperMapper,
+                             RawDataMapper rawDataMapper,
+                             ObjectMapper objectMapper) {
+        super(objectMapper, Duration.ofHours(12), BdrDadosFinanceirosDTO.class);
+        this.scraper = scraper;
+        this.repository = repository;
+        this.scraperMapper = scraperMapper;
+        this.rawDataMapper = rawDataMapper;
+    }
+
+    @Override
+    protected String normalize(String ticker) {
+        return ticker == null ? null : ticker.trim().toUpperCase();
+    }
+
+    @Override
+    protected Mono<Optional<Bdr>> findByTicker(String ticker) {
+        return Mono.fromCallable(() -> repository.findByTickerWithDetails(ticker))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @Override
+    protected Mono<BdrDadosFinanceirosDTO> scrape(String ticker) {
+        return scraper.scrape(ticker);
+    }
+
+    @Override
+    protected boolean isCacheValid(Bdr domain, Duration maxAge) {
+        Instant updatedAt = domain.getUpdatedAt();
+        return updatedAt != null && Duration.between(updatedAt, Instant.now()).compareTo(maxAge) < 0;
+    }
+
+    @Override
+    protected Bdr toDomain(BdrDadosFinanceirosDTO raw) {
+        return scraperMapper.toDomain(raw);
+    }
+
+    @Override
+    protected Bdr saveDomain(Bdr domain, BdrDadosFinanceirosDTO raw) {
+        String auditJson = null;
+        String rawHash = null;
+        try {
+            auditJson = serialize(raw);
+            rawHash = computeHash(raw.rawJson());
+        } catch (Exception ignored) {
+        }
+        return repository.saveReplacingChildren(domain, auditJson, rawHash);
+    }
+
+    @Override
+    protected Mono<BdrDadosFinanceirosDTO> readRawFromStore(String ticker) {
+        return Mono.fromCallable(() -> repository.findRawJsonByTicker(ticker))
+                .flatMap(optional -> optional
+                        .map(json -> {
+                            try {
+                                return Mono.just(deserialize(json));
+                            } catch (Exception e) {
+                                return Mono.<BdrDadosFinanceirosDTO>error(e);
+                            }
+                        })
+                        .orElseGet(Mono::empty))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @Override
+    public Mono<BdrRawDataResponse> getRawTickerData(String ticker) {
+        return super.getRawTickerDataAsResponse(ticker);
+    }
+
+    @Override
+    protected BdrRawDataResponse convertToRawResponse(BdrDadosFinanceirosDTO infraDto) {
+        return rawDataMapper.toBdrRawDataResponse(infraDto);
+    }
+
+    @Override
+    protected BdrRawDataResponse createFailedResponse(String ticker, String source, String error) {
+        return rawDataMapper.createFailedBdrResponse(ticker, source, error);
+    }
+
+    private String computeHash(Map<String, String> rawJson) throws NoSuchAlgorithmException {
+        if (rawJson == null || rawJson.isEmpty()) {
+            return null;
+        }
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        rawJson.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    digest.update(entry.getKey().getBytes(StandardCharsets.UTF_8));
+                    if (entry.getValue() != null) {
+                        digest.update(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                    }
+                });
+        return HexFormat.of().formatHex(digest.digest());
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/service/TickerDatabaseStrategy.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/application/service/TickerDatabaseStrategy.java
@@ -2,6 +2,7 @@ package br.dev.rodrigopinheiro.tickerscraper.application.service;
 
 
 import br.dev.rodrigopinheiro.tickerscraper.application.port.output.AcaoRepositoryPort;
+import br.dev.rodrigopinheiro.tickerscraper.application.port.output.BdrRepositoryPort;
 import br.dev.rodrigopinheiro.tickerscraper.application.port.output.FiiRepositoryPort;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.TipoAtivoResult;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.TipoAtivoFinanceiroVariavel;
@@ -21,7 +22,7 @@ public class TickerDatabaseStrategy {
 
     private final AcaoRepositoryPort acaoRepository;
     private final FiiRepositoryPort fiiRepository;
-    // TODO: Adicionar EtfRepositoryPort e BdrRepositoryPort quando criados
+    private final BdrRepositoryPort bdrRepository;
     
     /**
      * Verifica se ticker existe no banco e retorna o tipo
@@ -33,7 +34,7 @@ public class TickerDatabaseStrategy {
         Mono<Boolean> existeAcao = verificarExistencia(acaoRepository::existsByTicker, ticker);
         Mono<Boolean> existeFii = verificarExistencia(fiiRepository::existsByTicker, ticker);
         Mono<Boolean> existeEtf = Mono.just(false); // TODO: implementar quando EtfRepository existir
-        Mono<Boolean> existeBdr = Mono.just(false); // TODO: implementar quando BdrRepository existir
+        Mono<Boolean> existeBdr = verificarExistencia(bdrRepository::existsByTicker, ticker);
         
         return Mono.zip(existeAcao, existeFii, existeEtf, existeBdr)
             .map(tuple -> determinarTipo(ticker, tuple))

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
@@ -1,0 +1,269 @@
+package br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.mapper;
+
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.*;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.TipoAtivo;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.parser.IndicadorParser;
+import br.dev.rodrigopinheiro.tickerscraper.infrastructure.scraper.bdr.dto.*;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Mapper responsável por converter o agregado de scraping de BDR ({@link BdrDadosFinanceirosDTO})
+ * em objetos de domínio prontos para persistência.
+ */
+@Component
+public class BdrScraperMapper {
+
+    private static final Pattern YEAR_EXTRACTOR = Pattern.compile("(20\\d{2}|19\\d{2})");
+
+    public Bdr toDomain(BdrDadosFinanceirosDTO raw) {
+        if (raw == null) {
+            return null;
+        }
+
+        Bdr bdr = new Bdr();
+        bdr.setTicker(normalize(raw.ticker()));
+        bdr.setCodigoNegociacao(normalize(raw.ticker()));
+        bdr.setTipoAtivo(TipoAtivo.BDR);
+
+        // Informações de apresentação
+        BdrHtmlMetadataDTO metadata = raw.htmlMetadata();
+        if (metadata != null) {
+            bdr.setNomeEmpresa(resolveCompanyName(metadata));
+            bdr.setNomeAcaoOriginal(metadata.descricao());
+            bdr.setMercado(getMetaTag(metadata, "og:site_name"));
+        }
+        bdr.setMoedaDeReferencia(resolveCurrency(raw));
+        bdr.setPaisDeNegociacao(metadata != null ? getMetaTag(metadata, "og:locale") : null);
+
+        // Indicadores principais
+        BdrIndicadoresDTO indicadores = raw.indicadores();
+        BigDecimal precoAtual = findMonetario(indicadores, "PRECO ATUAL", "PREÇO ATUAL", "ULTIMO PRECO", "ÚLTIMO PREÇO", "PRICE");
+        BigDecimal variacaoDia = findPercentual(indicadores, "VARIACAO DIA", "VAR. DIA", "DIA");
+        BigDecimal variacaoMes = findPercentual(indicadores, "VARIACAO MES", "VAR. MES", "30D", "MÊS");
+        BigDecimal variacaoAno = findPercentual(indicadores, "VARIACAO ANO", "VAR. ANO", "12M", "ANO");
+        BigDecimal dividendYield = findPercentual(indicadores, "DIVIDEND YIELD", "DY");
+        BigDecimal precoAlvo = findMonetario(indicadores, "PRECO ALVO", "PREÇO ALVO", "TARGET");
+
+        bdr.setPrecoAtual(precoAtual);
+        bdr.setVariacaoDia(variacaoDia);
+        bdr.setVariacaoMes(variacaoMes);
+        bdr.setVariacaoAno(variacaoAno);
+        bdr.setDividendYield(dividendYield);
+        bdr.setPrecoAlvo(precoAlvo);
+
+        // Indicadores correntes detalhados
+        bdr.setCurrentIndicators(buildCurrentIndicators(indicadores, precoAtual, variacaoDia, variacaoMes, variacaoAno, dividendYield));
+
+        // Paridade
+        bdr.setParidade(mapParidade(indicadores.paridade()));
+
+        // Séries históricas e dividendos
+        bdr.setHistoricoDePrecos(mapPriceSeries(raw.cotacoes()));
+        bdr.setDividendosPorAno(mapDividendos(raw.dividendos()));
+        bdr.setIndicadoresHistoricos(mapHistoricalIndicators(indicadores));
+
+        // Demonstrativos ainda não parseados – armazenados como listas vazias para futuras iterações
+        bdr.setDreAnual(List.of());
+        bdr.setBpAnual(List.of());
+        bdr.setFcAnual(List.of());
+
+        // Metadados adicionais
+        bdr.setUpdatedAt(Optional.ofNullable(raw.updatedAt()).orElseGet(Instant::now));
+        bdr.setRawJson(raw.rawJson() == null ? Map.of() : new LinkedHashMap<>(raw.rawJson()));
+
+        return bdr;
+    }
+
+    private String normalize(String value) {
+        return value == null ? null : value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private String resolveCompanyName(BdrHtmlMetadataDTO metadata) {
+        if (metadata == null) {
+            return null;
+        }
+        Map<String, String> tags = metadata.metaTags();
+        if (tags != null) {
+            if (tags.containsKey("og:title")) {
+                return tags.get("og:title");
+            }
+            if (tags.containsKey("twitter:title")) {
+                return tags.get("twitter:title");
+            }
+        }
+        return metadata.titulo();
+    }
+
+    private String getMetaTag(BdrHtmlMetadataDTO metadata, String key) {
+        if (metadata == null || metadata.metaTags() == null) {
+            return null;
+        }
+        return metadata.metaTags().get(key);
+    }
+
+    private String resolveCurrency(BdrDadosFinanceirosDTO raw) {
+        if (raw.indicadores() != null && raw.indicadores().moedaPadrao() != null) {
+            return raw.indicadores().moedaPadrao();
+        }
+        if (raw.cotacoes() != null) {
+            return raw.cotacoes().moeda();
+        }
+        return null;
+    }
+
+    private BigDecimal findMonetario(BdrIndicadoresDTO indicadores, String... expectedNames) {
+        if (indicadores == null || indicadores.indicadoresMonetarios() == null) {
+            return null;
+        }
+        return findByNormalizedKey(indicadores.indicadoresMonetarios(), expectedNames);
+    }
+
+    private BigDecimal findPercentual(BdrIndicadoresDTO indicadores, String... expectedNames) {
+        if (indicadores == null || indicadores.indicadoresPercentuais() == null) {
+            return null;
+        }
+        return findByNormalizedKey(indicadores.indicadoresPercentuais(), expectedNames);
+    }
+
+    private BigDecimal findSimpleDecimal(BdrIndicadoresDTO indicadores, String... expectedNames) {
+        if (indicadores == null || indicadores.indicadoresSimples() == null) {
+            return null;
+        }
+        Map<String, Double> simples = indicadores.indicadoresSimples();
+        for (String candidate : expectedNames) {
+            String normalized = IndicadorParser.normalizar(candidate);
+            Optional<Map.Entry<String, Double>> match = simples.entrySet().stream()
+                    .filter(entry -> normalized.equalsIgnoreCase(IndicadorParser.normalizar(entry.getKey())))
+                    .findFirst();
+            if (match.isPresent() && match.get().getValue() != null) {
+                return BigDecimal.valueOf(match.get().getValue());
+            }
+        }
+        return null;
+    }
+
+    private BigDecimal findByNormalizedKey(Map<String, BigDecimal> source, String... expectedNames) {
+        if (source.isEmpty()) {
+            return null;
+        }
+        for (String candidate : expectedNames) {
+            String normalized = IndicadorParser.normalizar(candidate);
+            Optional<Map.Entry<String, BigDecimal>> match = source.entrySet().stream()
+                    .filter(entry -> normalized.equalsIgnoreCase(IndicadorParser.normalizar(entry.getKey())))
+                    .findFirst();
+            if (match.isPresent()) {
+                return match.get().getValue();
+            }
+        }
+        return null;
+    }
+
+    private CurrentIndicators buildCurrentIndicators(BdrIndicadoresDTO indicadores,
+                                                     BigDecimal precoAtual,
+                                                     BigDecimal variacaoDia,
+                                                     BigDecimal variacaoMes,
+                                                     BigDecimal variacaoAno,
+                                                     BigDecimal dividendYield) {
+        if (indicadores == null) {
+            return null;
+        }
+        CurrentIndicators current = new CurrentIndicators();
+        current.setUltimoPreco(precoAtual);
+        current.setVariacaoPercentualDia(variacaoDia);
+        current.setVariacaoPercentualMes(variacaoMes);
+        current.setVariacaoPercentualAno(variacaoAno);
+        current.setDividendYield(dividendYield);
+        current.setPrecoLucro(findSimpleDecimal(indicadores, "P/L", "P L", "PRICE TO EARNINGS"));
+        current.setPrecoValorPatrimonial(findSimpleDecimal(indicadores, "P/VP", "P VP", "PRICE TO BOOK"));
+        current.setValorMercado(findMonetario(indicadores, "VALOR DE MERCADO", "MARKET CAP"));
+        current.setVolumeMedio(findMonetario(indicadores, "VOLUME MEDIO", "VOLUME MÉDIO"));
+        return current;
+    }
+
+    private ParidadeBdr mapParidade(IndicadorParser.ParidadeBdrInfo info) {
+        if (info == null) {
+            return null;
+        }
+        ParidadeBdr paridade = new ParidadeBdr();
+        paridade.setFatorConversao(info.fatorConversao());
+        paridade.setMoedaOrigem(info.moedaReferencia());
+        paridade.setTickerOriginal(info.descricaoOriginal());
+        paridade.setBolsaOrigem(info.moedaReferencia());
+        return paridade;
+    }
+
+    private List<PricePoint> mapPriceSeries(BdrCotacoesDTO cotacoes) {
+        if (cotacoes == null || cotacoes.serie() == null) {
+            return List.of();
+        }
+        return cotacoes.serie().stream()
+                .filter(Objects::nonNull)
+                .map(point -> {
+                    PricePoint domain = new PricePoint();
+                    domain.setTimestamp(point.data());
+                    domain.setClosePrice(point.preco());
+                    return domain;
+                })
+                .sorted(Comparator.comparing(PricePoint::getTimestamp))
+                .collect(Collectors.toList());
+    }
+
+    private List<DividendYear> mapDividendos(BdrDividendosDTO dividendos) {
+        if (dividendos == null || dividendos.dividendos() == null || dividendos.dividendos().isEmpty()) {
+            return List.of();
+        }
+        Map<Integer, BigDecimal> acumuladoPorAno = new TreeMap<>();
+        for (BdrDividendoItemDTO item : dividendos.dividendos()) {
+            if (item == null || item.valor() == null) {
+                continue;
+            }
+            Integer ano = extractYear(item.periodo());
+            if (ano == null) {
+                continue;
+            }
+            acumuladoPorAno.merge(ano, item.valor(), BigDecimal::add);
+        }
+        return acumuladoPorAno.entrySet().stream()
+                .map(entry -> {
+                    DividendYear year = new DividendYear();
+                    year.setAno(entry.getKey());
+                    year.setTotalDividendo(entry.getValue().setScale(4, RoundingMode.HALF_UP));
+                    return year;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private Integer extractYear(String periodo) {
+        if (periodo == null) {
+            return null;
+        }
+        Matcher matcher = YEAR_EXTRACTOR.matcher(periodo);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1));
+        }
+        return null;
+    }
+
+    private List<HistoricalIndicator> mapHistoricalIndicators(BdrIndicadoresDTO indicadores) {
+        if (indicadores == null || indicadores.indicadoresSimples() == null || indicadores.indicadoresSimples().isEmpty()) {
+            return List.of();
+        }
+        return indicadores.indicadoresSimples().entrySet().stream()
+                .map(entry -> {
+                    HistoricalIndicator indicator = new HistoricalIndicator();
+                    indicator.setNomeIndicador(entry.getKey());
+                    indicator.setValor(entry.getValue() == null ? null : BigDecimal.valueOf(entry.getValue()));
+                    indicator.setAno(null); // API não fornece ano explícito
+                    return indicator;
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated BDR use case port/service plus mapper to translate scraper output into domain/raw responses
- expose BDR REST endpoints with DTOs and API mapper while updating the unified ticker service to serve BDR data
- extend raw data mapper and database strategy to handle BDR persistence and classification shortcuts

