### PR TITLE
Refatorar modelo BDR para novo esquema

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
@@ -10,13 +10,25 @@ import org.mapstruct.Mappings;
 public interface BdrApiMapper {
 
     @Mappings({
-            @Mapping(source = "historicoDePrecos", target = "historicoDePrecos"),
-            @Mapping(source = "dividendosPorAno", target = "dividendosPorAno"),
-            @Mapping(source = "indicadoresHistoricos", target = "indicadoresHistoricos"),
-            @Mapping(source = "dreAnual", target = "dreAnual"),
-            @Mapping(source = "bpAnual", target = "balancoPatrimonial"),
-            @Mapping(source = "fcAnual", target = "fluxoDeCaixa"),
-            @Mapping(source = "updatedAt", target = "atualizadoEm")
+            @Mapping(source = "nomeBdr", target = "nomeEmpresa"),
+            @Mapping(source = "setor", target = "mercado"),
+            @Mapping(source = "priceCurrency", target = "moedaDeReferencia"),
+            @Mapping(source = "cotacao", target = "precoAtual"),
+            @Mapping(source = "variacao12", target = "variacaoAno"),
+            @Mapping(source = "priceSeries", target = "historicoDePrecos"),
+            @Mapping(source = "dividendYears", target = "dividendosPorAno"),
+            @Mapping(source = "historicalIndicators", target = "indicadoresHistoricos"),
+            @Mapping(source = "dreYears", target = "dreAnual"),
+            @Mapping(source = "bpYears", target = "balancoPatrimonial"),
+            @Mapping(source = "fcYears", target = "fluxoDeCaixa"),
+            @Mapping(source = "updatedAt", target = "atualizadoEm"),
+            @Mapping(target = "nomeAcaoOriginal", ignore = true),
+            @Mapping(target = "codigoNegociacao", ignore = true),
+            @Mapping(target = "paisDeNegociacao", ignore = true),
+            @Mapping(target = "variacaoDia", ignore = true),
+            @Mapping(target = "variacaoMes", ignore = true),
+            @Mapping(target = "dividendYield", ignore = true),
+            @Mapping(target = "precoAlvo", ignore = true)
     })
     BdrResponseDTO toResponse(Bdr domain);
 

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrMapper.java
@@ -25,40 +25,45 @@ public interface BdrMapper {
             @Mapping(target = "id", ignore = true),
             @Mapping(source = "ticker", target = "ticker"),
             @Mapping(source = "tipoAtivo", target = "tipoAtivo"),
-            @Mapping(source = "nomeEmpresa", target = "nomeEmpresa"),
-            @Mapping(source = "nomeAcaoOriginal", target = "nomeAcaoOriginal"),
-            @Mapping(source = "codigoNegociacao", target = "codigoNegociacao"),
-            @Mapping(source = "mercado", target = "mercado"),
-            @Mapping(source = "paisDeNegociacao", target = "paisDeNegociacao"),
-            @Mapping(source = "moedaDeReferencia", target = "moedaDeReferencia"),
-            @Mapping(source = "precoAtual", target = "precoAtual"),
-            @Mapping(source = "variacaoDia", target = "variacaoDia"),
-            @Mapping(source = "variacaoMes", target = "variacaoMes"),
-            @Mapping(source = "variacaoAno", target = "variacaoAno"),
-            @Mapping(source = "dividendYield", target = "dividendYield"),
-            @Mapping(source = "precoAlvo", target = "precoAlvo"),
-            @Mapping(source = "historicoDePrecos", target = "priceSeries"),
-            @Mapping(source = "dividendosPorAno", target = "dividendYears"),
-            @Mapping(source = "indicadoresHistoricos", target = "historicalIndicators"),
-            @Mapping(source = "dreAnual", target = "dreYears"),
-            @Mapping(source = "bpAnual", target = "bpYears"),
-            @Mapping(source = "fcAnual", target = "fcYears"),
+            @Mapping(source = "nomeBdr", target = "nomeEmpresa"),
+            @Mapping(source = "setor", target = "mercado"),
+            @Mapping(source = "priceCurrency", target = "moedaDeReferencia"),
+            @Mapping(source = "cotacao", target = "precoAtual"),
+            @Mapping(source = "variacao12", target = "variacaoAno"),
+            @Mapping(source = "priceSeries", target = "priceSeries"),
+            @Mapping(source = "dividendYears", target = "dividendYears"),
+            @Mapping(source = "historicalIndicators", target = "historicalIndicators"),
+            @Mapping(source = "dreYears", target = "dreYears"),
+            @Mapping(source = "bpYears", target = "bpYears"),
+            @Mapping(source = "fcYears", target = "fcYears"),
             @Mapping(source = "currentIndicators", target = "currentIndicators"),
             @Mapping(source = "paridade", target = "paridade"),
             @Mapping(source = "updatedAt", target = "updatedAt"),
             @Mapping(source = "rawJson", target = "rawJson", qualifiedByName = "mapToJson"),
-            @Mapping(source = "rawJsonHash", target = "rawJsonHash")
+            @Mapping(source = "rawJsonHash", target = "rawJsonHash"),
+            @Mapping(target = "nomeAcaoOriginal", ignore = true),
+            @Mapping(target = "codigoNegociacao", ignore = true),
+            @Mapping(target = "paisDeNegociacao", ignore = true),
+            @Mapping(target = "variacaoDia", ignore = true),
+            @Mapping(target = "variacaoMes", ignore = true),
+            @Mapping(target = "dividendYield", ignore = true),
+            @Mapping(target = "precoAlvo", ignore = true)
     })
     BdrEntity toEntity(Bdr bdr);
 
     @InheritInverseConfiguration
     @Mappings({
-            @Mapping(source = "priceSeries", target = "historicoDePrecos"),
-            @Mapping(source = "dividendYears", target = "dividendosPorAno"),
-            @Mapping(source = "historicalIndicators", target = "indicadoresHistoricos"),
-            @Mapping(source = "dreYears", target = "dreAnual"),
-            @Mapping(source = "bpYears", target = "bpAnual"),
-            @Mapping(source = "fcYears", target = "fcAnual"),
+            @Mapping(source = "nomeEmpresa", target = "nomeBdr"),
+            @Mapping(source = "mercado", target = "setor"),
+            @Mapping(source = "moedaDeReferencia", target = "priceCurrency"),
+            @Mapping(source = "precoAtual", target = "cotacao"),
+            @Mapping(source = "variacaoAno", target = "variacao12"),
+            @Mapping(source = "priceSeries", target = "priceSeries"),
+            @Mapping(source = "dividendYears", target = "dividendYears"),
+            @Mapping(source = "historicalIndicators", target = "historicalIndicators"),
+            @Mapping(source = "dreYears", target = "dreYears"),
+            @Mapping(source = "bpYears", target = "bpYears"),
+            @Mapping(source = "fcYears", target = "fcYears"),
             @Mapping(source = "rawJson", target = "rawJson", qualifiedByName = "jsonToMap")
     })
     Bdr toDomain(BdrEntity entity);
@@ -96,7 +101,7 @@ public interface BdrMapper {
         } else {
             target.getPriceSeries().clear();
         }
-        List<PricePoint> pricePoints = source.getHistoricoDePrecos();
+        List<PricePoint> pricePoints = source.getPriceSeries();
         if (pricePoints != null) {
             List<BdrPriceSeriesEntity> entities = toPriceSeriesEntities(pricePoints);
             for (BdrPriceSeriesEntity entity : entities) {
@@ -112,7 +117,7 @@ public interface BdrMapper {
         } else {
             target.getDividendYears().clear();
         }
-        List<DividendYear> dividendYears = source.getDividendosPorAno();
+        List<DividendYear> dividendYears = source.getDividendYears();
         if (dividendYears != null) {
             List<BdrDividendYearlyEntity> entities = toDividendYearEntities(dividendYears);
             for (BdrDividendYearlyEntity entity : entities) {
@@ -128,7 +133,7 @@ public interface BdrMapper {
         } else {
             target.getHistoricalIndicators().clear();
         }
-        List<HistoricalIndicator> indicators = source.getIndicadoresHistoricos();
+        List<HistoricalIndicator> indicators = source.getHistoricalIndicators();
         if (indicators != null) {
             List<BdrHistoricalIndicatorEntity> entities = toHistoricalIndicatorEntities(indicators);
             for (BdrHistoricalIndicatorEntity entity : entities) {
@@ -144,7 +149,7 @@ public interface BdrMapper {
         } else {
             target.getDreYears().clear();
         }
-        List<DreYear> dreYears = source.getDreAnual();
+        List<DreYear> dreYears = source.getDreYears();
         if (dreYears != null) {
             List<BdrDreYearEntity> entities = toDreEntities(dreYears);
             for (BdrDreYearEntity entity : entities) {
@@ -160,7 +165,7 @@ public interface BdrMapper {
         } else {
             target.getBpYears().clear();
         }
-        List<BpYear> bpYears = source.getBpAnual();
+        List<BpYear> bpYears = source.getBpYears();
         if (bpYears != null) {
             List<BdrBpYearEntity> entities = toBpEntities(bpYears);
             for (BdrBpYearEntity entity : entities) {
@@ -176,7 +181,7 @@ public interface BdrMapper {
         } else {
             target.getFcYears().clear();
         }
-        List<FcYear> fcYears = source.getFcAnual();
+        List<FcYear> fcYears = source.getFcYears();
         if (fcYears != null) {
             List<BdrFcYearEntity> entities = toFcEntities(fcYears);
             for (BdrFcYearEntity entity : entities) {

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/Bdr.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/Bdr.java
@@ -10,27 +10,24 @@ import java.util.Map;
 public class Bdr {
 
     private String ticker;
-    private String nomeEmpresa;
-    private String nomeAcaoOriginal;
-    private String codigoNegociacao;
-    private String mercado;
-    private String paisDeNegociacao;
-    private String moedaDeReferencia;
-    private BigDecimal precoAtual;
-    private BigDecimal variacaoDia;
-    private BigDecimal variacaoMes;
-    private BigDecimal variacaoAno;
-    private BigDecimal dividendYield;
-    private BigDecimal precoAlvo;
+    private String investidorId;
     private TipoAtivo tipoAtivo = TipoAtivo.BDR;
+    private String nomeBdr;
+    private String setor;
+    private String industria;
+    private String priceCurrency;
+    private String financialsCurrency;
+    private BigDecimal cotacao;
+    private BigDecimal variacao12;
+    private MarketCap marketCap;
     private ParidadeBdr paridade;
     private CurrentIndicators currentIndicators;
-    private List<PricePoint> historicoDePrecos;
-    private List<DividendYear> dividendosPorAno;
-    private List<HistoricalIndicator> indicadoresHistoricos;
-    private List<DreYear> dreAnual;
-    private List<BpYear> bpAnual;
-    private List<FcYear> fcAnual;
+    private List<PricePoint> priceSeries;
+    private List<DividendYear> dividendYears;
+    private List<HistoricalIndicator> historicalIndicators;
+    private List<DreYear> dreYears;
+    private List<BpYear> bpYears;
+    private List<FcYear> fcYears;
     private Instant updatedAt;
     private Map<String, Object> rawJson;
     private String rawJsonHash;
@@ -43,100 +40,12 @@ public class Bdr {
         this.ticker = ticker == null ? null : ticker.trim().toUpperCase();
     }
 
-    public String getNomeEmpresa() {
-        return nomeEmpresa;
+    public String getInvestidorId() {
+        return investidorId;
     }
 
-    public void setNomeEmpresa(String nomeEmpresa) {
-        this.nomeEmpresa = nomeEmpresa;
-    }
-
-    public String getNomeAcaoOriginal() {
-        return nomeAcaoOriginal;
-    }
-
-    public void setNomeAcaoOriginal(String nomeAcaoOriginal) {
-        this.nomeAcaoOriginal = nomeAcaoOriginal;
-    }
-
-    public String getCodigoNegociacao() {
-        return codigoNegociacao;
-    }
-
-    public void setCodigoNegociacao(String codigoNegociacao) {
-        this.codigoNegociacao = codigoNegociacao;
-    }
-
-    public String getMercado() {
-        return mercado;
-    }
-
-    public void setMercado(String mercado) {
-        this.mercado = mercado;
-    }
-
-    public String getPaisDeNegociacao() {
-        return paisDeNegociacao;
-    }
-
-    public void setPaisDeNegociacao(String paisDeNegociacao) {
-        this.paisDeNegociacao = paisDeNegociacao;
-    }
-
-    public String getMoedaDeReferencia() {
-        return moedaDeReferencia;
-    }
-
-    public void setMoedaDeReferencia(String moedaDeReferencia) {
-        this.moedaDeReferencia = moedaDeReferencia;
-    }
-
-    public BigDecimal getPrecoAtual() {
-        return precoAtual;
-    }
-
-    public void setPrecoAtual(BigDecimal precoAtual) {
-        this.precoAtual = precoAtual;
-    }
-
-    public BigDecimal getVariacaoDia() {
-        return variacaoDia;
-    }
-
-    public void setVariacaoDia(BigDecimal variacaoDia) {
-        this.variacaoDia = variacaoDia;
-    }
-
-    public BigDecimal getVariacaoMes() {
-        return variacaoMes;
-    }
-
-    public void setVariacaoMes(BigDecimal variacaoMes) {
-        this.variacaoMes = variacaoMes;
-    }
-
-    public BigDecimal getVariacaoAno() {
-        return variacaoAno;
-    }
-
-    public void setVariacaoAno(BigDecimal variacaoAno) {
-        this.variacaoAno = variacaoAno;
-    }
-
-    public BigDecimal getDividendYield() {
-        return dividendYield;
-    }
-
-    public void setDividendYield(BigDecimal dividendYield) {
-        this.dividendYield = dividendYield;
-    }
-
-    public BigDecimal getPrecoAlvo() {
-        return precoAlvo;
-    }
-
-    public void setPrecoAlvo(BigDecimal precoAlvo) {
-        this.precoAlvo = precoAlvo;
+    public void setInvestidorId(String investidorId) {
+        this.investidorId = investidorId;
     }
 
     public TipoAtivo getTipoAtivo() {
@@ -145,6 +54,70 @@ public class Bdr {
 
     public void setTipoAtivo(TipoAtivo tipoAtivo) {
         this.tipoAtivo = tipoAtivo;
+    }
+
+    public String getNomeBdr() {
+        return nomeBdr;
+    }
+
+    public void setNomeBdr(String nomeBdr) {
+        this.nomeBdr = nomeBdr;
+    }
+
+    public String getSetor() {
+        return setor;
+    }
+
+    public void setSetor(String setor) {
+        this.setor = setor;
+    }
+
+    public String getIndustria() {
+        return industria;
+    }
+
+    public void setIndustria(String industria) {
+        this.industria = industria;
+    }
+
+    public String getPriceCurrency() {
+        return priceCurrency;
+    }
+
+    public void setPriceCurrency(String priceCurrency) {
+        this.priceCurrency = normalizeCurrency(priceCurrency);
+    }
+
+    public String getFinancialsCurrency() {
+        return financialsCurrency;
+    }
+
+    public void setFinancialsCurrency(String financialsCurrency) {
+        this.financialsCurrency = normalizeCurrency(financialsCurrency);
+    }
+
+    public BigDecimal getCotacao() {
+        return cotacao;
+    }
+
+    public void setCotacao(BigDecimal cotacao) {
+        this.cotacao = cotacao;
+    }
+
+    public BigDecimal getVariacao12() {
+        return variacao12;
+    }
+
+    public void setVariacao12(BigDecimal variacao12) {
+        this.variacao12 = variacao12;
+    }
+
+    public MarketCap getMarketCap() {
+        return marketCap;
+    }
+
+    public void setMarketCap(MarketCap marketCap) {
+        this.marketCap = marketCap;
     }
 
     public ParidadeBdr getParidade() {
@@ -163,52 +136,52 @@ public class Bdr {
         this.currentIndicators = currentIndicators;
     }
 
-    public List<PricePoint> getHistoricoDePrecos() {
-        return historicoDePrecos;
+    public List<PricePoint> getPriceSeries() {
+        return priceSeries;
     }
 
-    public void setHistoricoDePrecos(List<PricePoint> historicoDePrecos) {
-        this.historicoDePrecos = historicoDePrecos;
+    public void setPriceSeries(List<PricePoint> priceSeries) {
+        this.priceSeries = priceSeries;
     }
 
-    public List<DividendYear> getDividendosPorAno() {
-        return dividendosPorAno;
+    public List<DividendYear> getDividendYears() {
+        return dividendYears;
     }
 
-    public void setDividendosPorAno(List<DividendYear> dividendosPorAno) {
-        this.dividendosPorAno = dividendosPorAno;
+    public void setDividendYears(List<DividendYear> dividendYears) {
+        this.dividendYears = dividendYears;
     }
 
-    public List<HistoricalIndicator> getIndicadoresHistoricos() {
-        return indicadoresHistoricos;
+    public List<HistoricalIndicator> getHistoricalIndicators() {
+        return historicalIndicators;
     }
 
-    public void setIndicadoresHistoricos(List<HistoricalIndicator> indicadoresHistoricos) {
-        this.indicadoresHistoricos = indicadoresHistoricos;
+    public void setHistoricalIndicators(List<HistoricalIndicator> historicalIndicators) {
+        this.historicalIndicators = historicalIndicators;
     }
 
-    public List<DreYear> getDreAnual() {
-        return dreAnual;
+    public List<DreYear> getDreYears() {
+        return dreYears;
     }
 
-    public void setDreAnual(List<DreYear> dreAnual) {
-        this.dreAnual = dreAnual;
+    public void setDreYears(List<DreYear> dreYears) {
+        this.dreYears = dreYears;
     }
 
-    public List<BpYear> getBpAnual() {
-        return bpAnual;
+    public List<BpYear> getBpYears() {
+        return bpYears;
     }
 
-    public void setBpAnual(List<BpYear> bpAnual) {
-        this.bpAnual = bpAnual;
+    public void setBpYears(List<BpYear> bpYears) {
+        this.bpYears = bpYears;
     }
 
-    public List<FcYear> getFcAnual() {
-        return fcAnual;
+    public List<FcYear> getFcYears() {
+        return fcYears;
     }
 
-    public void setFcAnual(List<FcYear> fcAnual) {
-        this.fcAnual = fcAnual;
+    public void setFcYears(List<FcYear> fcYears) {
+        this.fcYears = fcYears;
     }
 
     public Instant getUpdatedAt() {
@@ -233,5 +206,13 @@ public class Bdr {
 
     public void setRawJsonHash(String rawJsonHash) {
         this.rawJsonHash = rawJsonHash;
+    }
+
+    private String normalizeCurrency(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed.toUpperCase();
     }
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/MarketCap.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/MarketCap.java
@@ -1,0 +1,46 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+/**
+ * Representação de auditoria para o market cap de um BDR.
+ */
+public class MarketCap {
+
+    private BigDecimal value;
+    private String currency;
+    private String quality;
+    private String raw;
+
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getQuality() {
+        return quality;
+    }
+
+    public void setQuality(String quality) {
+        this.quality = quality;
+    }
+
+    public String getRaw() {
+        return raw;
+    }
+
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
+}


### PR DESCRIPTION
## Summary
- alinhar `Bdr` aos campos previstos na nova migração, com moedas, cotação, variação e coleções renomeadas
- introduzir modelo `MarketCap` para suportar auditoria de market cap
- atualizar os mapeadores de scraping, API e persistência para usarem os novos nomes de campos

