### PR TITLE
Add currency tracking to dividend year data

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDividendYearResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDividendYearResponseDTO.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 public record BdrDividendYearResponseDTO(
         Integer ano,
         BigDecimal totalDividendo,
-        BigDecimal dividendYield
+        BigDecimal dividendYield,
+        String currency
 ) {
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDividendYearlyEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDividendYearlyEntity.java
@@ -30,4 +30,7 @@ public class BdrDividendYearlyEntity {
 
     @Column(name = "dividend_yield", precision = 19, scale = 6)
     private BigDecimal dividendYield;
+
+    @Column(name = "currency")
+    private String currency;
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrDividendYearMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrDividendYearMapper.java
@@ -17,7 +17,8 @@ public interface BdrDividendYearMapper {
             @Mapping(target = "bdr", ignore = true),
             @Mapping(source = "ano", target = "ano"),
             @Mapping(source = "totalDividendo", target = "totalDividendo"),
-            @Mapping(source = "dividendYield", target = "dividendYield")
+            @Mapping(source = "dividendYield", target = "dividendYield"),
+            @Mapping(source = "currency", target = "currency")
     })
     BdrDividendYearlyEntity toEntity(DividendYear year);
 

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DividendYear.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DividendYear.java
@@ -7,6 +7,7 @@ public class DividendYear {
     private Integer ano;
     private BigDecimal totalDividendo;
     private BigDecimal dividendYield;
+    private String currency;
 
     public Integer getAno() {
         return ano;
@@ -30,5 +31,13 @@ public class DividendYear {
 
     public void setDividendYield(BigDecimal dividendYield) {
         this.dividendYield = dividendYield;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
     }
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
@@ -223,6 +223,7 @@ public class BdrScraperMapper {
             return List.of();
         }
         Map<Integer, BigDecimal> acumuladoPorAno = new TreeMap<>();
+        Map<Integer, String> currencyPorAno = new HashMap<>();
         for (BdrDividendoItemDTO item : dividendos.dividendos()) {
             if (item == null || item.valor() == null) {
                 continue;
@@ -232,12 +233,16 @@ public class BdrScraperMapper {
                 continue;
             }
             acumuladoPorAno.merge(ano, item.valor(), BigDecimal::add);
+            if (currencyPorAno.get(ano) == null && item.moeda() != null) {
+                currencyPorAno.put(ano, item.moeda());
+            }
         }
         return acumuladoPorAno.entrySet().stream()
                 .map(entry -> {
                     DividendYear year = new DividendYear();
                     year.setAno(entry.getKey());
                     year.setTotalDividendo(entry.getValue().setScale(4, RoundingMode.HALF_UP));
+                    year.setCurrency(currencyPorAno.get(entry.getKey()));
                     return year;
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## Summary
- add a currency field to the DividendYear domain model and expose it via the web DTO
- persist the new currency field on dividend year entities and map it through MapStruct
- capture dividend currency information during scraping so yearly aggregates retain the original currency

