### PR TITLE
Refatorar indicadores históricos de BDR

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrHistoricalIndicatorResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrHistoricalIndicatorResponseDTO.java
@@ -3,8 +3,21 @@ package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
 import java.math.BigDecimal;
 
 public record BdrHistoricalIndicatorResponseDTO(
-        String indicador,
-        Integer ano,
-        BigDecimal valor
+        Integer year,
+        BigDecimal pl,
+        BigDecimal pvp,
+        BigDecimal psr,
+        BigDecimal pEbit,
+        BigDecimal pEbitda,
+        BigDecimal pAtivo,
+        BigDecimal roe,
+        BigDecimal roic,
+        BigDecimal roa,
+        BigDecimal margemBruta,
+        BigDecimal margemOperacional,
+        BigDecimal margemLiquida,
+        BigDecimal vpa,
+        BigDecimal lpa,
+        BigDecimal patrimonioPorAtivos
 ) {
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrHistoricalIndicatorEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrHistoricalIndicatorEntity.java
@@ -22,12 +22,51 @@ public class BdrHistoricalIndicatorEntity {
     @JoinColumn(name = "bdr_id")
     private BdrEntity bdr;
 
-    @Column(name = "nome_indicador")
-    private String nomeIndicador;
+    @Column(name = "year")
+    private Integer year;
 
-    @Column(name = "ano")
-    private Integer ano;
+    @Column(name = "pl", precision = 19, scale = 6)
+    private BigDecimal pl;
 
-    @Column(name = "valor", precision = 19, scale = 6)
-    private BigDecimal valor;
+    @Column(name = "pvp", precision = 19, scale = 6)
+    private BigDecimal pvp;
+
+    @Column(name = "psr", precision = 19, scale = 6)
+    private BigDecimal psr;
+
+    @Column(name = "p_ebit", precision = 19, scale = 6)
+    private BigDecimal pEbit;
+
+    @Column(name = "p_ebitda", precision = 19, scale = 6)
+    private BigDecimal pEbitda;
+
+    @Column(name = "p_ativo", precision = 19, scale = 6)
+    private BigDecimal pAtivo;
+
+    @Column(name = "roe", precision = 19, scale = 6)
+    private BigDecimal roe;
+
+    @Column(name = "roic", precision = 19, scale = 6)
+    private BigDecimal roic;
+
+    @Column(name = "roa", precision = 19, scale = 6)
+    private BigDecimal roa;
+
+    @Column(name = "margem_bruta", precision = 19, scale = 6)
+    private BigDecimal margemBruta;
+
+    @Column(name = "margem_operacional", precision = 19, scale = 6)
+    private BigDecimal margemOperacional;
+
+    @Column(name = "margem_liquida", precision = 19, scale = 6)
+    private BigDecimal margemLiquida;
+
+    @Column(name = "vpa", precision = 19, scale = 6)
+    private BigDecimal vpa;
+
+    @Column(name = "lpa", precision = 19, scale = 6)
+    private BigDecimal lpa;
+
+    @Column(name = "patrimonio_por_ativos", precision = 19, scale = 6)
+    private BigDecimal patrimonioPorAtivos;
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrHistoricalIndicatorMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrHistoricalIndicatorMapper.java
@@ -14,10 +14,7 @@ public interface BdrHistoricalIndicatorMapper {
 
     @Mappings({
             @Mapping(target = "id", ignore = true),
-            @Mapping(target = "bdr", ignore = true),
-            @Mapping(source = "nomeIndicador", target = "nomeIndicador"),
-            @Mapping(source = "ano", target = "ano"),
-            @Mapping(source = "valor", target = "valor")
+            @Mapping(target = "bdr", ignore = true)
     })
     BdrHistoricalIndicatorEntity toEntity(HistoricalIndicator indicator);
 

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/HistoricalIndicator.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/HistoricalIndicator.java
@@ -4,31 +4,148 @@ import java.math.BigDecimal;
 
 public class HistoricalIndicator {
 
-    private String nomeIndicador;
-    private Integer ano;
-    private BigDecimal valor;
+    private Integer year;
+    private BigDecimal pl;
+    private BigDecimal pvp;
+    private BigDecimal psr;
+    private BigDecimal pEbit;
+    private BigDecimal pEbitda;
+    private BigDecimal pAtivo;
+    private BigDecimal roe;
+    private BigDecimal roic;
+    private BigDecimal roa;
+    private BigDecimal margemBruta;
+    private BigDecimal margemOperacional;
+    private BigDecimal margemLiquida;
+    private BigDecimal vpa;
+    private BigDecimal lpa;
+    private BigDecimal patrimonioPorAtivos;
 
-    public String getNomeIndicador() {
-        return nomeIndicador;
+    public Integer getYear() {
+        return year;
     }
 
-    public void setNomeIndicador(String nomeIndicador) {
-        this.nomeIndicador = nomeIndicador;
+    public void setYear(Integer year) {
+        this.year = year;
     }
 
-    public Integer getAno() {
-        return ano;
+    public BigDecimal getPl() {
+        return pl;
     }
 
-    public void setAno(Integer ano) {
-        this.ano = ano;
+    public void setPl(BigDecimal pl) {
+        this.pl = pl;
     }
 
-    public BigDecimal getValor() {
-        return valor;
+    public BigDecimal getPvp() {
+        return pvp;
     }
 
-    public void setValor(BigDecimal valor) {
-        this.valor = valor;
+    public void setPvp(BigDecimal pvp) {
+        this.pvp = pvp;
+    }
+
+    public BigDecimal getPsr() {
+        return psr;
+    }
+
+    public void setPsr(BigDecimal psr) {
+        this.psr = psr;
+    }
+
+    public BigDecimal getPEbit() {
+        return pEbit;
+    }
+
+    public void setPEbit(BigDecimal pEbit) {
+        this.pEbit = pEbit;
+    }
+
+    public BigDecimal getPEbitda() {
+        return pEbitda;
+    }
+
+    public void setPEbitda(BigDecimal pEbitda) {
+        this.pEbitda = pEbitda;
+    }
+
+    public BigDecimal getPAtivo() {
+        return pAtivo;
+    }
+
+    public void setPAtivo(BigDecimal pAtivo) {
+        this.pAtivo = pAtivo;
+    }
+
+    public BigDecimal getRoe() {
+        return roe;
+    }
+
+    public void setRoe(BigDecimal roe) {
+        this.roe = roe;
+    }
+
+    public BigDecimal getRoic() {
+        return roic;
+    }
+
+    public void setRoic(BigDecimal roic) {
+        this.roic = roic;
+    }
+
+    public BigDecimal getRoa() {
+        return roa;
+    }
+
+    public void setRoa(BigDecimal roa) {
+        this.roa = roa;
+    }
+
+    public BigDecimal getMargemBruta() {
+        return margemBruta;
+    }
+
+    public void setMargemBruta(BigDecimal margemBruta) {
+        this.margemBruta = margemBruta;
+    }
+
+    public BigDecimal getMargemOperacional() {
+        return margemOperacional;
+    }
+
+    public void setMargemOperacional(BigDecimal margemOperacional) {
+        this.margemOperacional = margemOperacional;
+    }
+
+    public BigDecimal getMargemLiquida() {
+        return margemLiquida;
+    }
+
+    public void setMargemLiquida(BigDecimal margemLiquida) {
+        this.margemLiquida = margemLiquida;
+    }
+
+    public BigDecimal getVpa() {
+        return vpa;
+    }
+
+    public void setVpa(BigDecimal vpa) {
+        this.vpa = vpa;
+    }
+
+    public BigDecimal getLpa() {
+        return lpa;
+    }
+
+    public void setLpa(BigDecimal lpa) {
+        this.lpa = lpa;
+    }
+
+    public BigDecimal getPatrimonioPorAtivos() {
+        return patrimonioPorAtivos;
+    }
+
+    public void setPatrimonioPorAtivos(BigDecimal patrimonioPorAtivos) {
+        this.patrimonioPorAtivos = patrimonioPorAtivos;
     }
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
@@ -14,6 +14,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * Mapper responsável por converter o agregado de scraping de BDR ({@link BdrDadosFinanceirosDTO})
  * em objetos de domínio prontos para persistência.
@@ -255,17 +257,78 @@ public class BdrScraperMapper {
     }
 
     private List<HistoricalIndicator> mapHistoricalIndicators(BdrIndicadoresDTO indicadores) {
-        if (indicadores == null || indicadores.indicadoresSimples() == null || indicadores.indicadoresSimples().isEmpty()) {
+        if (indicadores == null || indicadores.raw() == null) {
             return List.of();
         }
-        return indicadores.indicadoresSimples().entrySet().stream()
-                .map(entry -> {
-                    HistoricalIndicator indicator = new HistoricalIndicator();
-                    indicator.setNomeIndicador(entry.getKey());
-                    indicator.setValor(entry.getValue() == null ? null : BigDecimal.valueOf(entry.getValue()));
-                    indicator.setAno(null); // API não fornece ano explícito
-                    return indicator;
-                })
-                .collect(Collectors.toList());
+        JsonNode historyNode = indicadores.raw().get("history");
+        if (historyNode == null || !historyNode.isArray() || historyNode.isEmpty()) {
+            return List.of();
+        }
+        List<HistoricalIndicator> history = new ArrayList<>();
+        for (JsonNode item : historyNode) {
+            if (item == null || !item.isObject()) {
+                continue;
+            }
+            HistoricalIndicator indicator = new HistoricalIndicator();
+            indicator.setYear(extractYear(item.get("year")));
+            indicator.setPl(asBigDecimal(item.get("pl")));
+            indicator.setPvp(asBigDecimal(item.get("pvp")));
+            indicator.setPsr(asBigDecimal(item.get("psr")));
+            indicator.setPEbit(asBigDecimal(item.get("pEbit")));
+            indicator.setPEbitda(asBigDecimal(item.get("pEbitda")));
+            indicator.setPAtivo(asBigDecimal(item.get("pAtivo")));
+            indicator.setRoe(asBigDecimal(item.get("roe")));
+            indicator.setRoic(asBigDecimal(item.get("roic")));
+            indicator.setRoa(asBigDecimal(item.get("roa")));
+            indicator.setMargemBruta(asBigDecimal(item.get("margemBruta")));
+            indicator.setMargemOperacional(asBigDecimal(item.get("margemOperacional")));
+            indicator.setMargemLiquida(asBigDecimal(item.get("margemLiquida")));
+            indicator.setVpa(asBigDecimal(item.get("vpa")));
+            indicator.setLpa(asBigDecimal(item.get("lpa")));
+            indicator.setPatrimonioPorAtivos(asBigDecimal(item.get("patrimonioPorAtivos")));
+            history.add(indicator);
+        }
+        return history;
+    }
+
+    private Integer extractYear(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isInt()) {
+            return node.intValue();
+        }
+        if (node.isTextual()) {
+            String text = node.asText();
+            if (text == null || text.isBlank()) {
+                return null;
+            }
+            try {
+                return Integer.parseInt(text.trim());
+            } catch (NumberFormatException ignored) {
+                return IndicadorParser.safeParseDouble(text)
+                        .map(Double::intValue)
+                        .orElse(null);
+            }
+        }
+        if (node.canConvertToInt()) {
+            return node.intValue();
+        }
+        return null;
+    }
+
+    private BigDecimal asBigDecimal(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            return node.decimalValue();
+        }
+        if (node.isTextual()) {
+            return IndicadorParser.safeParseDouble(node.asText())
+                    .map(BigDecimal::valueOf)
+                    .orElse(null);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- expandir o domínio, entidade JPA e DTOs de indicadores históricos para suportar ano e razões financeiras completas
- atualizar o mapeamento do scraper para popular os novos campos a partir do bloco `history` da API da B3

