### PR TITLE
Refactor DRE year metrics to capture quality metadata

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDreYearResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDreYearResponseDTO.java
@@ -1,13 +1,11 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
 
-import java.math.BigDecimal;
-
 public record BdrDreYearResponseDTO(
         Integer ano,
-        BigDecimal receitaLiquida,
-        BigDecimal lucroLiquido,
-        BigDecimal ebitda,
-        BigDecimal ebit,
-        BigDecimal margemLiquida
+        BdrQualityMetricResponseDTO receitaTotalUsd,
+        BdrQualityMetricResponseDTO lucroBrutoUsd,
+        BdrQualityMetricResponseDTO ebitdaUsd,
+        BdrQualityMetricResponseDTO ebitUsd,
+        BdrQualityMetricResponseDTO lucroLiquidoUsd
 ) {
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrQualityMetricResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrQualityMetricResponseDTO.java
@@ -1,0 +1,12 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
+
+import java.math.BigDecimal;
+
+public record BdrQualityMetricResponseDTO(
+        BigDecimal value,
+        Quality quality,
+        String raw
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
@@ -44,6 +44,8 @@ public interface BdrApiMapper {
 
     BdrDreYearResponseDTO toResponse(DreYear year);
 
+    BdrQualityMetricResponseDTO toResponse(DreYear.Metric metric);
+
     BdrBpYearResponseDTO toResponse(BpYear year);
 
     BdrFcYearResponseDTO toResponse(FcYear year);

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDreYearEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDreYearEntity.java
@@ -3,10 +3,8 @@ package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.math.BigDecimal;
-
 @Entity
-@Table(name = "bdr_dre_year")
+@Table(name = "bdr_dre_yearly")
 @Getter
 @Setter
 @Builder
@@ -22,21 +20,46 @@ public class BdrDreYearEntity {
     @JoinColumn(name = "bdr_id")
     private BdrEntity bdr;
 
-    @Column(name = "ano")
+    @Column(name = "year")
     private Integer ano;
 
-    @Column(name = "receita_liquida", precision = 19, scale = 2)
-    private BigDecimal receitaLiquida;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "receita_total_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "receita_total_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "receita_total_raw"))
+    })
+    private QualityMetricEmbeddable receitaTotalUsd;
 
-    @Column(name = "lucro_liquido", precision = 19, scale = 2)
-    private BigDecimal lucroLiquido;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "lucro_bruto_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "lucro_bruto_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "lucro_bruto_raw"))
+    })
+    private QualityMetricEmbeddable lucroBrutoUsd;
 
-    @Column(name = "ebitda", precision = 19, scale = 2)
-    private BigDecimal ebitda;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "ebitda_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "ebitda_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "ebitda_raw"))
+    })
+    private QualityMetricEmbeddable ebitdaUsd;
 
-    @Column(name = "ebit", precision = 19, scale = 2)
-    private BigDecimal ebit;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "ebit_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "ebit_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "ebit_raw"))
+    })
+    private QualityMetricEmbeddable ebitUsd;
 
-    @Column(name = "margem_liquida", precision = 19, scale = 6)
-    private BigDecimal margemLiquida;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "lucro_liquido_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "lucro_liquido_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "lucro_liquido_raw"))
+    })
+    private QualityMetricEmbeddable lucroLiquidoUsd;
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/QualityMetricEmbeddable.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/QualityMetricEmbeddable.java
@@ -1,0 +1,47 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.converter.QualityAttributeConverter;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embeddable;
+
+import java.math.BigDecimal;
+
+@Embeddable
+public class QualityMetricEmbeddable {
+
+    @Column(name = "value", precision = 30, scale = 6)
+    private BigDecimal value;
+
+    @Convert(converter = QualityAttributeConverter.class)
+    @Column(name = "quality", columnDefinition = "quality_enum")
+    private Quality quality = Quality.UNKNOWN;
+
+    @Column(name = "raw")
+    private String raw;
+
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+    public Quality getQuality() {
+        return quality;
+    }
+
+    public void setQuality(Quality quality) {
+        this.quality = quality == null ? Quality.UNKNOWN : quality;
+    }
+
+    public String getRaw() {
+        return raw;
+    }
+
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/converter/QualityAttributeConverter.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/converter/QualityAttributeConverter.java
@@ -1,0 +1,25 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.converter;
+
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class QualityAttributeConverter implements AttributeConverter<Quality, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Quality attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getValue();
+    }
+
+    @Override
+    public Quality convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return Quality.UNKNOWN;
+        }
+        return Quality.fromValue(dbData);
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrFinancialStatementMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrFinancialStatementMapper.java
@@ -1,8 +1,6 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
 
-import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrBpYearEntity;
-import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrDreYearEntity;
-import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrFcYearEntity;
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.*;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.BpYear;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.DreYear;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.FcYear;
@@ -18,7 +16,12 @@ public interface BdrFinancialStatementMapper {
 
     @Mappings({
             @Mapping(target = "id", ignore = true),
-            @Mapping(target = "bdr", ignore = true)
+            @Mapping(target = "bdr", ignore = true),
+            @Mapping(source = "receitaTotalUsd", target = "receitaTotalUsd"),
+            @Mapping(source = "lucroBrutoUsd", target = "lucroBrutoUsd"),
+            @Mapping(source = "ebitdaUsd", target = "ebitdaUsd"),
+            @Mapping(source = "ebitUsd", target = "ebitUsd"),
+            @Mapping(source = "lucroLiquidoUsd", target = "lucroLiquidoUsd")
     })
     BdrDreYearEntity toEntity(DreYear year);
 
@@ -54,4 +57,26 @@ public interface BdrFinancialStatementMapper {
     List<BdrFcYearEntity> toFcEntityList(List<FcYear> source);
 
     List<FcYear> toFcDomainList(List<BdrFcYearEntity> source);
+
+    default QualityMetricEmbeddable toEmbeddable(DreYear.Metric metric) {
+        if (metric == null) {
+            return null;
+        }
+        QualityMetricEmbeddable embeddable = new QualityMetricEmbeddable();
+        embeddable.setValue(metric.getValue());
+        embeddable.setQuality(metric.getQuality());
+        embeddable.setRaw(metric.getRaw());
+        return embeddable;
+    }
+
+    default DreYear.Metric toDomain(QualityMetricEmbeddable embeddable) {
+        if (embeddable == null) {
+            return null;
+        }
+        DreYear.Metric metric = new DreYear.Metric();
+        metric.setValue(embeddable.getValue());
+        metric.setQuality(embeddable.getQuality());
+        metric.setRaw(embeddable.getRaw());
+        return metric;
+    }
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DreYear.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DreYear.java
@@ -1,15 +1,17 @@
 package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
 
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
+
 import java.math.BigDecimal;
 
 public class DreYear {
 
     private Integer ano;
-    private BigDecimal receitaLiquida;
-    private BigDecimal lucroLiquido;
-    private BigDecimal ebitda;
-    private BigDecimal ebit;
-    private BigDecimal margemLiquida;
+    private Metric receitaTotalUsd;
+    private Metric lucroBrutoUsd;
+    private Metric ebitdaUsd;
+    private Metric ebitUsd;
+    private Metric lucroLiquidoUsd;
 
     public Integer getAno() {
         return ano;
@@ -19,43 +21,74 @@ public class DreYear {
         this.ano = ano;
     }
 
-    public BigDecimal getReceitaLiquida() {
-        return receitaLiquida;
+    public Metric getReceitaTotalUsd() {
+        return receitaTotalUsd;
     }
 
-    public void setReceitaLiquida(BigDecimal receitaLiquida) {
-        this.receitaLiquida = receitaLiquida;
+    public void setReceitaTotalUsd(Metric receitaTotalUsd) {
+        this.receitaTotalUsd = receitaTotalUsd;
     }
 
-    public BigDecimal getLucroLiquido() {
-        return lucroLiquido;
+    public Metric getLucroBrutoUsd() {
+        return lucroBrutoUsd;
     }
 
-    public void setLucroLiquido(BigDecimal lucroLiquido) {
-        this.lucroLiquido = lucroLiquido;
+    public void setLucroBrutoUsd(Metric lucroBrutoUsd) {
+        this.lucroBrutoUsd = lucroBrutoUsd;
     }
 
-    public BigDecimal getEbitda() {
-        return ebitda;
+    public Metric getEbitdaUsd() {
+        return ebitdaUsd;
     }
 
-    public void setEbitda(BigDecimal ebitda) {
-        this.ebitda = ebitda;
+    public void setEbitdaUsd(Metric ebitdaUsd) {
+        this.ebitdaUsd = ebitdaUsd;
     }
 
-    public BigDecimal getEbit() {
-        return ebit;
+    public Metric getEbitUsd() {
+        return ebitUsd;
     }
 
-    public void setEbit(BigDecimal ebit) {
-        this.ebit = ebit;
+    public void setEbitUsd(Metric ebitUsd) {
+        this.ebitUsd = ebitUsd;
     }
 
-    public BigDecimal getMargemLiquida() {
-        return margemLiquida;
+    public Metric getLucroLiquidoUsd() {
+        return lucroLiquidoUsd;
     }
 
-    public void setMargemLiquida(BigDecimal margemLiquida) {
-        this.margemLiquida = margemLiquida;
+    public void setLucroLiquidoUsd(Metric lucroLiquidoUsd) {
+        this.lucroLiquidoUsd = lucroLiquidoUsd;
+    }
+
+    public static class Metric {
+
+        private BigDecimal value;
+        private Quality quality = Quality.UNKNOWN;
+        private String raw;
+
+        public BigDecimal getValue() {
+            return value;
+        }
+
+        public void setValue(BigDecimal value) {
+            this.value = value;
+        }
+
+        public Quality getQuality() {
+            return quality;
+        }
+
+        public void setQuality(Quality quality) {
+            this.quality = quality == null ? Quality.UNKNOWN : quality;
+        }
+
+        public String getRaw() {
+            return raw;
+        }
+
+        public void setRaw(String raw) {
+            this.raw = raw;
+        }
     }
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/enums/Quality.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/enums/Quality.java
@@ -1,0 +1,35 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum Quality {
+    OK("ok"),
+    MISSING("missing"),
+    ZERO_REAL("zero_real"),
+    UNKNOWN("unknown");
+
+    private final String value;
+
+    Quality(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static Quality fromValue(String value) {
+        if (value == null || value.isBlank()) {
+            return UNKNOWN;
+        }
+        return Arrays.stream(values())
+                .filter(quality -> quality.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElse(UNKNOWN);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap each DRE metric in a reusable quality metric object and expose it through the API
- add a Quality enum plus JPA converter/embeddable to persist value, quality and raw data per metric
- align BDR DRE entity, mapper and DTOs with the new receitaTotalUsd/lucroBrutoUsd/... field names

## Testing
- `./mvnw -q -DskipTests package` *(fails: cannot reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d40477b53c832abb0b81afeb073488