### PR TITLE
Refatora BpYear para expor valores auditados

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/AuditedValueResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/AuditedValueResponseDTO.java
@@ -1,0 +1,10 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
+
+import java.math.BigDecimal;
+
+public record AuditedValueResponseDTO(
+        BigDecimal value,
+        String quality,
+        String raw
+) {
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrBpYearResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrBpYearResponseDTO.java
@@ -1,13 +1,10 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
 
-import java.math.BigDecimal;
-
 public record BdrBpYearResponseDTO(
         Integer ano,
-        BigDecimal ativosTotais,
-        BigDecimal passivosTotais,
-        BigDecimal patrimonioLiquido,
-        BigDecimal caixaEDisponibilidades,
-        BigDecimal dividaBruta
+        AuditedValueResponseDTO ativosTotais,
+        AuditedValueResponseDTO passivosTotais,
+        AuditedValueResponseDTO dividaLongoPrazo,
+        AuditedValueResponseDTO pl
 ) {
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
@@ -47,4 +47,6 @@ public interface BdrApiMapper {
     BdrBpYearResponseDTO toResponse(BpYear year);
 
     BdrFcYearResponseDTO toResponse(FcYear year);
+
+    AuditedValueResponseDTO toResponse(AuditedValue value);
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/AuditedBigDecimalEmbeddable.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/AuditedBigDecimalEmbeddable.java
@@ -1,0 +1,23 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Embeddable
+public class AuditedBigDecimalEmbeddable {
+
+    @Column(precision = 19, scale = 2)
+    private BigDecimal value;
+
+    @Column(length = 50)
+    private String quality;
+
+    @Column(columnDefinition = "TEXT")
+    private String raw;
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrBpYearEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrBpYearEntity.java
@@ -3,8 +3,6 @@ package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.math.BigDecimal;
-
 @Entity
 @Table(name = "bdr_bp_year")
 @Getter
@@ -25,18 +23,35 @@ public class BdrBpYearEntity {
     @Column(name = "ano")
     private Integer ano;
 
-    @Column(name = "ativos_totais", precision = 19, scale = 2)
-    private BigDecimal ativosTotais;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "ativos_totais", precision = 19, scale = 2)),
+            @AttributeOverride(name = "quality", column = @Column(name = "ativos_totais_quality", length = 50)),
+            @AttributeOverride(name = "raw", column = @Column(name = "ativos_totais_raw", columnDefinition = "TEXT"))
+    })
+    private AuditedBigDecimalEmbeddable ativosTotais;
 
-    @Column(name = "passivos_totais", precision = 19, scale = 2)
-    private BigDecimal passivosTotais;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "passivos_totais", precision = 19, scale = 2)),
+            @AttributeOverride(name = "quality", column = @Column(name = "passivos_totais_quality", length = 50)),
+            @AttributeOverride(name = "raw", column = @Column(name = "passivos_totais_raw", columnDefinition = "TEXT"))
+    })
+    private AuditedBigDecimalEmbeddable passivosTotais;
 
-    @Column(name = "patrimonio_liquido", precision = 19, scale = 2)
-    private BigDecimal patrimonioLiquido;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "divida_longo_prazo", precision = 19, scale = 2)),
+            @AttributeOverride(name = "quality", column = @Column(name = "divida_longo_prazo_quality", length = 50)),
+            @AttributeOverride(name = "raw", column = @Column(name = "divida_longo_prazo_raw", columnDefinition = "TEXT"))
+    })
+    private AuditedBigDecimalEmbeddable dividaLongoPrazo;
 
-    @Column(name = "caixa_disponibilidades", precision = 19, scale = 2)
-    private BigDecimal caixaEDisponibilidades;
-
-    @Column(name = "divida_bruta", precision = 19, scale = 2)
-    private BigDecimal dividaBruta;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "value", column = @Column(name = "pl", precision = 19, scale = 2)),
+            @AttributeOverride(name = "quality", column = @Column(name = "pl_quality", length = 50)),
+            @AttributeOverride(name = "raw", column = @Column(name = "pl_raw", columnDefinition = "TEXT"))
+    })
+    private AuditedBigDecimalEmbeddable pl;
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrFinancialStatementMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrFinancialStatementMapper.java
@@ -1,8 +1,10 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
 
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.AuditedBigDecimalEmbeddable;
 import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrBpYearEntity;
 import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrDreYearEntity;
 import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrFcYearEntity;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.AuditedValue;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.BpYear;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.DreYear;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.FcYear;
@@ -41,6 +43,10 @@ public interface BdrFinancialStatementMapper {
     List<BdrBpYearEntity> toBpEntityList(List<BpYear> source);
 
     List<BpYear> toBpDomainList(List<BdrBpYearEntity> source);
+
+    AuditedBigDecimalEmbeddable toEntity(AuditedValue value);
+
+    AuditedValue toDomain(AuditedBigDecimalEmbeddable embeddable);
 
     @Mappings({
             @Mapping(target = "id", ignore = true),

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/AuditedValue.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/AuditedValue.java
@@ -1,0 +1,37 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+import java.math.BigDecimal;
+
+/**
+ * Representa um valor numérico acompanhado de metadados de auditoria.
+ */
+public class AuditedValue {
+
+    private BigDecimal value;
+    private String quality;
+    private String raw;
+
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+    public String getQuality() {
+        return quality;
+    }
+
+    public void setQuality(String quality) {
+        this.quality = quality;
+    }
+
+    public String getRaw() {
+        return raw;
+    }
+
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/BpYear.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/BpYear.java
@@ -1,15 +1,12 @@
 package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
 
-import java.math.BigDecimal;
-
 public class BpYear {
 
     private Integer ano;
-    private BigDecimal ativosTotais;
-    private BigDecimal passivosTotais;
-    private BigDecimal patrimonioLiquido;
-    private BigDecimal caixaEDisponibilidades;
-    private BigDecimal dividaBruta;
+    private AuditedValue ativosTotais;
+    private AuditedValue passivosTotais;
+    private AuditedValue dividaLongoPrazo;
+    private AuditedValue pl;
 
     public Integer getAno() {
         return ano;
@@ -19,43 +16,35 @@ public class BpYear {
         this.ano = ano;
     }
 
-    public BigDecimal getAtivosTotais() {
+    public AuditedValue getAtivosTotais() {
         return ativosTotais;
     }
 
-    public void setAtivosTotais(BigDecimal ativosTotais) {
+    public void setAtivosTotais(AuditedValue ativosTotais) {
         this.ativosTotais = ativosTotais;
     }
 
-    public BigDecimal getPassivosTotais() {
+    public AuditedValue getPassivosTotais() {
         return passivosTotais;
     }
 
-    public void setPassivosTotais(BigDecimal passivosTotais) {
+    public void setPassivosTotais(AuditedValue passivosTotais) {
         this.passivosTotais = passivosTotais;
     }
 
-    public BigDecimal getPatrimonioLiquido() {
-        return patrimonioLiquido;
+    public AuditedValue getDividaLongoPrazo() {
+        return dividaLongoPrazo;
     }
 
-    public void setPatrimonioLiquido(BigDecimal patrimonioLiquido) {
-        this.patrimonioLiquido = patrimonioLiquido;
+    public void setDividaLongoPrazo(AuditedValue dividaLongoPrazo) {
+        this.dividaLongoPrazo = dividaLongoPrazo;
     }
 
-    public BigDecimal getCaixaEDisponibilidades() {
-        return caixaEDisponibilidades;
+    public AuditedValue getPl() {
+        return pl;
     }
 
-    public void setCaixaEDisponibilidades(BigDecimal caixaEDisponibilidades) {
-        this.caixaEDisponibilidades = caixaEDisponibilidades;
-    }
-
-    public BigDecimal getDividaBruta() {
-        return dividaBruta;
-    }
-
-    public void setDividaBruta(BigDecimal dividaBruta) {
-        this.dividaBruta = dividaBruta;
+    public void setPl(AuditedValue pl) {
+        this.pl = pl;
     }
 }


### PR DESCRIPTION
## Summary
- atualiza o domínio de BpYear para utilizar objetos auditados com value/quality/raw para os principais saldos
- ajusta DTOs e mapper da API para refletirem a nova estrutura com ativos totais, passivos totais, dívida de longo prazo e PL
- refatora a camada de persistência criando embutidos JPA para armazenar os valores auditados

## Testing
- `./mvnw -q -DskipTests compile` *(falha: Non-resolvable parent POM for br.dev.rodrigopinheiro:tickerscraper:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 5, column 10)*

------
https://chatgpt.com/codex/tasks/task_e_68d404790b3c832a89309fa69c132869