### PR TITLE
Add BDR market cap value object

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/Bdr.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/Bdr.java
@@ -19,7 +19,7 @@ public class Bdr {
     private String financialsCurrency;
     private BigDecimal cotacao;
     private BigDecimal variacao12;
-    private MarketCap marketCap;
+    private BdrMarketCap marketCap;
     private ParidadeBdr paridade;
     private CurrentIndicators currentIndicators;
     private List<PricePoint> priceSeries;
@@ -112,11 +112,11 @@ public class Bdr {
         this.variacao12 = variacao12;
     }
 
-    public MarketCap getMarketCap() {
+    public BdrMarketCap getMarketCap() {
         return marketCap;
     }
 
-    public void setMarketCap(MarketCap marketCap) {
+    public void setMarketCap(BdrMarketCap marketCap) {
         this.marketCap = marketCap;
     }
 

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/BdrMarketCap.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/BdrMarketCap.java
@@ -5,7 +5,7 @@ import java.math.BigDecimal;
 /**
  * Representação de auditoria para o market cap de um BDR.
  */
-public class MarketCap {
+public class BdrMarketCap {
 
     private BigDecimal value;
     private String currency;


### PR DESCRIPTION
## Summary
- introduce the BdrMarketCap value object to represent market cap details
- wire the optional BdrMarketCap field into the Bdr aggregate with appropriate accessors


