### PR TITLE
Refactor BDR parity domain to new structure

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrParidadeResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrParidadeResponseDTO.java
@@ -1,11 +1,15 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
 
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.ParidadeMethod;
+
 import java.math.BigDecimal;
+import java.time.Instant;
 
 public record BdrParidadeResponseDTO(
-        BigDecimal fatorConversao,
-        String tickerOriginal,
-        String bolsaOrigem,
-        String moedaOrigem
+        Integer ratio,
+        ParidadeMethod method,
+        BigDecimal confidence,
+        Instant lastVerifiedAt,
+        String raw
 ) {
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrParidadeEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrParidadeEntity.java
@@ -1,9 +1,11 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
 
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.ParidadeMethod;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 
 @Entity
 @Table(name = "bdr_paridade")
@@ -22,15 +24,19 @@ public class BdrParidadeEntity {
     @JoinColumn(name = "bdr_id", unique = true)
     private BdrEntity bdr;
 
-    @Column(name = "fator_conversao", precision = 19, scale = 6)
-    private BigDecimal fatorConversao;
+    @Column(name = "value")
+    private Integer ratio;
 
-    @Column(name = "ticker_original")
-    private String tickerOriginal;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "method")
+    private ParidadeMethod method;
 
-    @Column(name = "bolsa_origem")
-    private String bolsaOrigem;
+    @Column(name = "confidence", precision = 4, scale = 3)
+    private BigDecimal confidence;
 
-    @Column(name = "moeda_origem")
-    private String moedaOrigem;
+    @Column(name = "last_verified_at")
+    private Instant lastVerifiedAt;
+
+    @Column(name = "raw", columnDefinition = "TEXT")
+    private String raw;
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/ParidadeBdr.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/ParidadeBdr.java
@@ -1,43 +1,53 @@
 package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 
 public class ParidadeBdr {
 
-    private BigDecimal fatorConversao;
-    private String tickerOriginal;
-    private String bolsaOrigem;
-    private String moedaOrigem;
+    private Integer ratio;
+    private ParidadeMethod method;
+    private BigDecimal confidence;
+    private Instant lastVerifiedAt;
+    private String raw;
 
-    public BigDecimal getFatorConversao() {
-        return fatorConversao;
+    public Integer getRatio() {
+        return ratio;
     }
 
-    public void setFatorConversao(BigDecimal fatorConversao) {
-        this.fatorConversao = fatorConversao;
+    public void setRatio(Integer ratio) {
+        this.ratio = ratio;
     }
 
-    public String getTickerOriginal() {
-        return tickerOriginal;
+    public ParidadeMethod getMethod() {
+        return method;
     }
 
-    public void setTickerOriginal(String tickerOriginal) {
-        this.tickerOriginal = tickerOriginal;
+    public void setMethod(ParidadeMethod method) {
+        this.method = method;
     }
 
-    public String getBolsaOrigem() {
-        return bolsaOrigem;
+    public BigDecimal getConfidence() {
+        return confidence;
     }
 
-    public void setBolsaOrigem(String bolsaOrigem) {
-        this.bolsaOrigem = bolsaOrigem;
+    public void setConfidence(BigDecimal confidence) {
+        this.confidence = confidence;
     }
 
-    public String getMoedaOrigem() {
-        return moedaOrigem;
+    public Instant getLastVerifiedAt() {
+        return lastVerifiedAt;
     }
 
-    public void setMoedaOrigem(String moedaOrigem) {
-        this.moedaOrigem = moedaOrigem;
+    public void setLastVerifiedAt(Instant lastVerifiedAt) {
+        this.lastVerifiedAt = lastVerifiedAt;
+    }
+
+    public String getRaw() {
+        return raw;
+    }
+
+    public void setRaw(String raw) {
+        this.raw = raw;
     }
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/ParidadeMethod.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/ParidadeMethod.java
@@ -1,0 +1,8 @@
+package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
+
+public enum ParidadeMethod {
+    SOURCE_HTML,
+    SOURCE_B3,
+    SOURCE_DEPOSITARY,
+    INFERRED_PRICE
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
@@ -195,11 +195,30 @@ public class BdrScraperMapper {
             return null;
         }
         ParidadeBdr paridade = new ParidadeBdr();
-        paridade.setFatorConversao(info.fatorConversao());
-        paridade.setMoedaOrigem(info.moedaReferencia());
-        paridade.setTickerOriginal(info.descricaoOriginal());
-        paridade.setBolsaOrigem(info.moedaReferencia());
+        paridade.setRatio(calculateRatio(info));
+        paridade.setMethod(ParidadeMethod.SOURCE_HTML);
+        paridade.setLastVerifiedAt(Instant.now());
+        paridade.setRaw(info.descricaoOriginal());
         return paridade;
+    }
+
+    private Integer calculateRatio(IndicadorParser.ParidadeBdrInfo info) {
+        if (info.quantidadeBdr() == null || info.quantidadeAcoes() == null) {
+            return null;
+        }
+        if (info.quantidadeAcoes().compareTo(BigDecimal.ZERO) == 0) {
+            return null;
+        }
+        BigDecimal ratio = info.quantidadeBdr().divide(info.quantidadeAcoes(), 8, RoundingMode.HALF_UP);
+        BigDecimal normalized = ratio.stripTrailingZeros();
+        if (normalized.scale() <= 0) {
+            try {
+                return normalized.intValueExact();
+            } catch (ArithmeticException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private List<PricePoint> mapPriceSeries(BdrCotacoesDTO cotacoes) {


### PR DESCRIPTION
## Summary
- replace the ParidadeBdr attributes with ratio, method, confidence, lastVerifiedAt and raw, introducing the ParidadeMethod enum
- update the persistence entity, API response DTO and scraper mapper to use the new structure and compute the parity ratio from scraped data

## Testing
- ./mvnw -q test *(fails: unable to download parent POM because repo.maven.apache.org is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d4047af544832a9ba9fb3795232d0d