### PR TITLE
Atualiza série de preços de BDR para LocalDate

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrPricePointResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrPricePointResponseDTO.java
@@ -1,14 +1,10 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
 
 import java.math.BigDecimal;
-import java.time.Instant;
+import java.time.LocalDate;
 
 public record BdrPricePointResponseDTO(
-        Instant timestamp,
-        BigDecimal openPrice,
-        BigDecimal highPrice,
-        BigDecimal lowPrice,
-        BigDecimal closePrice,
-        BigDecimal volume
+        LocalDate dt,
+        BigDecimal close
 ) {
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
@@ -51,6 +51,8 @@ public interface BdrApiMapper {
 
     BdrCurrentIndicatorsResponseDTO toCurrentIndicatorsResponse(CurrentIndicators indicators);
 
+    @Mapping(source = "date", target = "dt")
+    @Mapping(source = "close", target = "close")
     BdrPricePointResponseDTO toPricePointResponse(PricePoint pricePoint);
 
 

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrPriceSeriesEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrPriceSeriesEntity.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "bdr_price_series")
@@ -23,21 +23,9 @@ public class BdrPriceSeriesEntity {
     @JoinColumn(name = "bdr_id")
     private BdrEntity bdr;
 
-    @Column(name = "timestamp")
-    private OffsetDateTime timestamp;
+    @Column(name = "dt", nullable = false)
+    private LocalDate dt;
 
-    @Column(name = "open_price", precision = 19, scale = 6)
-    private BigDecimal openPrice;
-
-    @Column(name = "high_price", precision = 19, scale = 6)
-    private BigDecimal highPrice;
-
-    @Column(name = "low_price", precision = 19, scale = 6)
-    private BigDecimal lowPrice;
-
-    @Column(name = "close_price", precision = 19, scale = 6)
-    private BigDecimal closePrice;
-
-    @Column(name = "volume", precision = 19, scale = 6)
-    private BigDecimal volume;
+    @Column(name = "close", precision = 19, scale = 6, nullable = false)
+    private BigDecimal close;
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrPriceSeriesMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrPriceSeriesMapper.java
@@ -9,18 +9,14 @@ import org.mapstruct.Mappings;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring", uses = TimeMapper.class)
+@Mapper(componentModel = "spring")
 public interface BdrPriceSeriesMapper {
 
     @Mappings({
             @Mapping(target = "id", ignore = true),
             @Mapping(target = "bdr", ignore = true),
-            @Mapping(source = "timestamp", target = "timestamp"),
-            @Mapping(source = "openPrice", target = "openPrice"),
-            @Mapping(source = "highPrice", target = "highPrice"),
-            @Mapping(source = "lowPrice", target = "lowPrice"),
-            @Mapping(source = "closePrice", target = "closePrice"),
-            @Mapping(source = "volume", target = "volume")
+            @Mapping(source = "date", target = "dt"),
+            @Mapping(source = "close", target = "close")
     })
     BdrPriceSeriesEntity toEntity(PricePoint point);
 

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -243,12 +245,19 @@ public class BdrScraperMapper {
                 .filter(Objects::nonNull)
                 .map(point -> {
                     PricePoint domain = new PricePoint();
-                    domain.setTimestamp(point.data());
-                    domain.setClosePrice(point.preco());
+                    domain.setDate(convertToLocalDate(point.data()));
+                    domain.setClose(point.preco());
                     return domain;
                 })
-                .sorted(Comparator.comparing(PricePoint::getTimestamp))
+                .sorted(Comparator.comparing(PricePoint::getDate))
                 .collect(Collectors.toList());
+    }
+
+    private LocalDate convertToLocalDate(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+        return instant.atZone(ZoneOffset.UTC).toLocalDate();
     }
 
     private List<DividendYear> mapDividendos(BdrDividendosDTO dividendos) {


### PR DESCRIPTION
## Summary
- mapear a entidade `BdrPriceSeries` para usar a coluna `dt` como `LocalDate` e manter apenas o valor de fechamento
- ajustar DTOs e mapeamentos MapStruct para refletir os campos `dt` e `close`
- normalizar a conversão de `Instant` para `LocalDate` ao montar os pontos da série histórica

