### PR TITLE
Rename dividend year fields and set currency default

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDividendYearResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrDividendYearResponseDTO.java
@@ -3,8 +3,8 @@ package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
 import java.math.BigDecimal;
 
 public record BdrDividendYearResponseDTO(
-        Integer ano,
-        BigDecimal totalDividendo,
+        Integer year,
+        BigDecimal valor,
         BigDecimal dividendYield,
         String currency
 ) {

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDividendYearlyEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrDividendYearlyEntity.java
@@ -22,15 +22,16 @@ public class BdrDividendYearlyEntity {
     @JoinColumn(name = "bdr_id")
     private BdrEntity bdr;
 
-    @Column(name = "ano")
-    private Integer ano;
+    @Column(name = "year")
+    private Integer year;
 
-    @Column(name = "total_dividendo", precision = 19, scale = 6)
-    private BigDecimal totalDividendo;
+    @Column(name = "valor", precision = 19, scale = 6)
+    private BigDecimal valor;
 
     @Column(name = "dividend_yield", precision = 19, scale = 6)
     private BigDecimal dividendYield;
 
-    @Column(name = "currency")
-    private String currency;
+    @Builder.Default
+    @Column(name = "currency", nullable = false)
+    private String currency = "USD";
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrDividendYearMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrDividendYearMapper.java
@@ -15,8 +15,8 @@ public interface BdrDividendYearMapper {
     @Mappings({
             @Mapping(target = "id", ignore = true),
             @Mapping(target = "bdr", ignore = true),
-            @Mapping(source = "ano", target = "ano"),
-            @Mapping(source = "totalDividendo", target = "totalDividendo"),
+            @Mapping(source = "year", target = "year"),
+            @Mapping(source = "valor", target = "valor"),
             @Mapping(source = "dividendYield", target = "dividendYield"),
             @Mapping(source = "currency", target = "currency")
     })

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DividendYear.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/DividendYear.java
@@ -4,25 +4,25 @@ import java.math.BigDecimal;
 
 public class DividendYear {
 
-    private Integer ano;
-    private BigDecimal totalDividendo;
+    private Integer year;
+    private BigDecimal valor;
     private BigDecimal dividendYield;
     private String currency;
 
-    public Integer getAno() {
-        return ano;
+    public Integer getYear() {
+        return year;
     }
 
-    public void setAno(Integer ano) {
-        this.ano = ano;
+    public void setYear(Integer year) {
+        this.year = year;
     }
 
-    public BigDecimal getTotalDividendo() {
-        return totalDividendo;
+    public BigDecimal getValor() {
+        return valor;
     }
 
-    public void setTotalDividendo(BigDecimal totalDividendo) {
-        this.totalDividendo = totalDividendo;
+    public void setValor(BigDecimal valor) {
+        this.valor = valor;
     }
 
     public BigDecimal getDividendYield() {

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/infrastructure/scraper/bdr/mapper/BdrScraperMapper.java
@@ -282,9 +282,9 @@ public class BdrScraperMapper {
         return acumuladoPorAno.entrySet().stream()
                 .map(entry -> {
                     DividendYear year = new DividendYear();
-                    year.setAno(entry.getKey());
-                    year.setTotalDividendo(entry.getValue().setScale(4, RoundingMode.HALF_UP));
-                    year.setCurrency(currencyPorAno.get(entry.getKey()));
+                    year.setYear(entry.getKey());
+                    year.setValor(entry.getValue().setScale(4, RoundingMode.HALF_UP));
+                    year.setCurrency(currencyPorAno.getOrDefault(entry.getKey(), "USD"));
                     return year;
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## Summary
- rename dividend year fields from ano/totalDividendo to year/valor across domain, DTO, mapper, and entity layers
- ensure persisted entity uses the renamed columns and defaults the currency column to USD
- update scraper mapping to populate the renamed fields and fall back to USD when no currency is scraped

