### PR TITLE
Refatora métricas de BDR para valores auditados com qualidade

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/AuditedValueResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/AuditedValueResponseDTO.java
@@ -1,10 +1,12 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
 
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
+
 import java.math.BigDecimal;
 
 public record AuditedValueResponseDTO(
         BigDecimal value,
-        String quality,
+        Quality quality,
         String raw
 ) {
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrFcValueResponseDTO.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/dto/BdrFcValueResponseDTO.java
@@ -1,10 +1,12 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.input.web.dto;
 
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
+
 import java.math.BigDecimal;
 
 public record BdrFcValueResponseDTO(
-        BigDecimal valor,
-        String quality,
+        BigDecimal value,
+        Quality quality,
         String raw
 ) {
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/input/web/mapper/BdrApiMapper.java
@@ -70,7 +70,7 @@ public interface BdrApiMapper {
         if (value == null) {
             return null;
         }
-        return new BdrFcValueResponseDTO(value.getValor(), value.getQuality(), value.getRaw());
+        return new BdrFcValueResponseDTO(value.getValue(), value.getQuality(), value.getRaw());
     }
 
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/AuditedBigDecimalEmbeddable.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/AuditedBigDecimalEmbeddable.java
@@ -1,6 +1,9 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
 
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.converter.QualityAttributeConverter;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,11 +15,12 @@ import java.math.BigDecimal;
 @Embeddable
 public class AuditedBigDecimalEmbeddable {
 
-    @Column(precision = 19, scale = 2)
+    @Column(precision = 30, scale = 6)
     private BigDecimal value;
 
-    @Column(length = 50)
-    private String quality;
+    @Convert(converter = QualityAttributeConverter.class)
+    @Column(columnDefinition = "quality_enum")
+    private Quality quality = Quality.UNKNOWN;
 
     @Column(columnDefinition = "TEXT")
     private String raw;

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrBpYearEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrBpYearEntity.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "bdr_bp_year")
+@Table(name = "bdr_bp_yearly")
 @Getter
 @Setter
 @Builder
@@ -20,38 +20,38 @@ public class BdrBpYearEntity {
     @JoinColumn(name = "bdr_id")
     private BdrEntity bdr;
 
-    @Column(name = "ano")
+    @Column(name = "year")
     private Integer ano;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "value", column = @Column(name = "ativos_totais", precision = 19, scale = 2)),
-            @AttributeOverride(name = "quality", column = @Column(name = "ativos_totais_quality", length = 50)),
-            @AttributeOverride(name = "raw", column = @Column(name = "ativos_totais_raw", columnDefinition = "TEXT"))
+            @AttributeOverride(name = "value", column = @Column(name = "ativos_totais_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "ativos_totais_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "ativos_totais_raw"))
     })
     private AuditedBigDecimalEmbeddable ativosTotais;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "value", column = @Column(name = "passivos_totais", precision = 19, scale = 2)),
-            @AttributeOverride(name = "quality", column = @Column(name = "passivos_totais_quality", length = 50)),
-            @AttributeOverride(name = "raw", column = @Column(name = "passivos_totais_raw", columnDefinition = "TEXT"))
+            @AttributeOverride(name = "value", column = @Column(name = "passivos_totais_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "passivos_totais_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "passivos_totais_raw"))
     })
     private AuditedBigDecimalEmbeddable passivosTotais;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "value", column = @Column(name = "divida_longo_prazo", precision = 19, scale = 2)),
-            @AttributeOverride(name = "quality", column = @Column(name = "divida_longo_prazo_quality", length = 50)),
-            @AttributeOverride(name = "raw", column = @Column(name = "divida_longo_prazo_raw", columnDefinition = "TEXT"))
+            @AttributeOverride(name = "value", column = @Column(name = "divida_lp_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "divida_lp_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "divida_lp_raw"))
     })
     private AuditedBigDecimalEmbeddable dividaLongoPrazo;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "value", column = @Column(name = "pl", precision = 19, scale = 2)),
-            @AttributeOverride(name = "quality", column = @Column(name = "pl_quality", length = 50)),
-            @AttributeOverride(name = "raw", column = @Column(name = "pl_raw", columnDefinition = "TEXT"))
+            @AttributeOverride(name = "value", column = @Column(name = "pl_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "pl_qual", columnDefinition = "quality_enum")),
+            @AttributeOverride(name = "raw", column = @Column(name = "pl_raw"))
     })
     private AuditedBigDecimalEmbeddable pl;
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrFcYearEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrFcYearEntity.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "bdr_fc_year")
+@Table(name = "bdr_fc_yearly")
 @Getter
 @Setter
 @Builder
@@ -20,29 +20,29 @@ public class BdrFcYearEntity {
     @JoinColumn(name = "bdr_id")
     private BdrEntity bdr;
 
-    @Column(name = "ano")
+    @Column(name = "year")
     private Integer ano;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "valor", column = @Column(name = "fco_val", precision = 30, scale = 6)),
-            @AttributeOverride(name = "quality", column = @Column(name = "fco_qual")),
+            @AttributeOverride(name = "value", column = @Column(name = "fco_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "fco_qual", columnDefinition = "quality_enum")),
             @AttributeOverride(name = "raw", column = @Column(name = "fco_raw"))
     })
     private QualityValueEmbeddable fluxoCaixaOperacional;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "valor", column = @Column(name = "fci_val", precision = 30, scale = 6)),
-            @AttributeOverride(name = "quality", column = @Column(name = "fci_qual")),
+            @AttributeOverride(name = "value", column = @Column(name = "fci_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "fci_qual", columnDefinition = "quality_enum")),
             @AttributeOverride(name = "raw", column = @Column(name = "fci_raw"))
     })
     private QualityValueEmbeddable fluxoCaixaInvestimento;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "valor", column = @Column(name = "fcf_val", precision = 30, scale = 6)),
-            @AttributeOverride(name = "quality", column = @Column(name = "fcf_qual")),
+            @AttributeOverride(name = "value", column = @Column(name = "fcf_val", precision = 30, scale = 6)),
+            @AttributeOverride(name = "quality", column = @Column(name = "fcf_qual", columnDefinition = "quality_enum")),
             @AttributeOverride(name = "raw", column = @Column(name = "fcf_raw"))
     })
     private QualityValueEmbeddable fluxoCaixaFinanciamento;

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/QualityValueEmbeddable.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/QualityValueEmbeddable.java
@@ -1,6 +1,9 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
 
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.converter.QualityAttributeConverter;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,11 +15,12 @@ import java.math.BigDecimal;
 @Setter
 public class QualityValueEmbeddable {
 
-    @Column(name = "valor", precision = 30, scale = 6)
-    private BigDecimal valor;
+    @Column(name = "value", precision = 30, scale = 6)
+    private BigDecimal value;
 
-    @Column(name = "quality")
-    private String quality;
+    @Convert(converter = QualityAttributeConverter.class)
+    @Column(name = "quality", columnDefinition = "quality_enum")
+    private Quality quality = Quality.UNKNOWN;
 
     @Column(name = "raw")
     private String raw;

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrFinancialStatementMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrFinancialStatementMapper.java
@@ -1,12 +1,14 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.bdr;
 
 
-import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.AuditedBigDecimalEmbeddable;
 import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrBpYearEntity;
 import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrDreYearEntity;
 import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.BdrFcYearEntity;
 import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.QualityValueEmbeddable;
 
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.AuditedBigDecimalEmbeddable;
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.QualityMetricEmbeddable;
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.AuditedValue;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.BpYear;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.DreYear;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.FcYear;
@@ -55,12 +57,34 @@ public interface BdrFinancialStatementMapper {
 
     List<FcYear> toFcDomainList(List<BdrFcYearEntity> source);
 
+    default QualityMetricEmbeddable toEmbeddable(DreYear.Metric metric) {
+        if (metric == null) {
+            return null;
+        }
+        QualityMetricEmbeddable embeddable = new QualityMetricEmbeddable();
+        embeddable.setValue(metric.getValue());
+        embeddable.setQuality(metric.getQuality());
+        embeddable.setRaw(metric.getRaw());
+        return embeddable;
+    }
+
+    default DreYear.Metric toMetric(QualityMetricEmbeddable embeddable) {
+        if (embeddable == null) {
+            return null;
+        }
+        DreYear.Metric metric = new DreYear.Metric();
+        metric.setValue(embeddable.getValue());
+        metric.setQuality(embeddable.getQuality());
+        metric.setRaw(embeddable.getRaw());
+        return metric;
+    }
+
     default QualityValueEmbeddable toEmbeddable(QualityValue value) {
         if (value == null) {
             return null;
         }
         QualityValueEmbeddable embeddable = new QualityValueEmbeddable();
-        embeddable.setValor(value.getValor());
+        embeddable.setValue(value.getValue());
         embeddable.setQuality(value.getQuality());
         embeddable.setRaw(value.getRaw());
         return embeddable;
@@ -71,10 +95,32 @@ public interface BdrFinancialStatementMapper {
             return null;
         }
         QualityValue qualityValue = new QualityValue();
-        qualityValue.setValor(value.getValor());
+        qualityValue.setValue(value.getValue());
         qualityValue.setQuality(value.getQuality());
         qualityValue.setRaw(value.getRaw());
         return qualityValue;
 
+    }
+
+    default AuditedBigDecimalEmbeddable toEmbeddable(AuditedValue value) {
+        if (value == null) {
+            return null;
+        }
+        AuditedBigDecimalEmbeddable embeddable = new AuditedBigDecimalEmbeddable();
+        embeddable.setValue(value.getValue());
+        embeddable.setQuality(value.getQuality());
+        embeddable.setRaw(value.getRaw());
+        return embeddable;
+    }
+
+    default AuditedValue toDomain(AuditedBigDecimalEmbeddable embeddable) {
+        if (embeddable == null) {
+            return null;
+        }
+        AuditedValue value = new AuditedValue();
+        value.setValue(embeddable.getValue());
+        value.setQuality(embeddable.getQuality());
+        value.setRaw(embeddable.getRaw());
+        return value;
     }
 }

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/AuditedValue.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/AuditedValue.java
@@ -1,5 +1,7 @@
 package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
 
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
+
 import java.math.BigDecimal;
 
 /**
@@ -8,7 +10,7 @@ import java.math.BigDecimal;
 public class AuditedValue {
 
     private BigDecimal value;
-    private String quality;
+    private Quality quality = Quality.UNKNOWN;
     private String raw;
 
     public BigDecimal getValue() {
@@ -19,12 +21,12 @@ public class AuditedValue {
         this.value = value;
     }
 
-    public String getQuality() {
+    public Quality getQuality() {
         return quality;
     }
 
-    public void setQuality(String quality) {
-        this.quality = quality;
+    public void setQuality(Quality quality) {
+        this.quality = quality == null ? Quality.UNKNOWN : quality;
     }
 
     public String getRaw() {

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/QualityValue.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/domain/model/bdr/QualityValue.java
@@ -1,5 +1,7 @@
 package br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr;
 
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.enums.Quality;
+
 import java.math.BigDecimal;
 
 /**
@@ -7,24 +9,24 @@ import java.math.BigDecimal;
  */
 public class QualityValue {
 
-    private BigDecimal valor;
-    private String quality;
+    private BigDecimal value;
+    private Quality quality = Quality.UNKNOWN;
     private String raw;
 
-    public BigDecimal getValor() {
-        return valor;
+    public BigDecimal getValue() {
+        return value;
     }
 
-    public void setValor(BigDecimal valor) {
-        this.valor = valor;
+    public void setValue(BigDecimal value) {
+        this.value = value;
     }
 
-    public String getQuality() {
+    public Quality getQuality() {
         return quality;
     }
 
-    public void setQuality(String quality) {
-        this.quality = quality;
+    public void setQuality(Quality quality) {
+        this.quality = quality == null ? Quality.UNKNOWN : quality;
     }
 
     public String getRaw() {


### PR DESCRIPTION
## Summary
- atualiza os DTOs e modelos de domínio para expor métricas monetárias com Quality em vez de String
- ajusta embeddables JPA e entidades de BDR para usar colunas *_val, *_qual, *_raw com conversor de Quality
- acrescenta conversões específicas no mapper financeiro para montar métricas auditadas
