### PR TITLE
Mapear enum de paridade e alinhar coluna value

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrParidadeEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrParidadeEntity.java
@@ -25,10 +25,10 @@ public class BdrParidadeEntity {
     private BdrEntity bdr;
 
     @Column(name = "value")
-    private Integer ratio;
+    private Integer value;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "method")
+    @Column(name = "method", columnDefinition = "paridade_method_enum")
     private ParidadeMethod method;
 
     @Column(name = "confidence", precision = 4, scale = 3)

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrParidadeMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrParidadeMapper.java
@@ -12,7 +12,8 @@ public interface BdrParidadeMapper {
 
     @Mappings({
             @Mapping(target = "id", ignore = true),
-            @Mapping(target = "bdr", ignore = true)
+            @Mapping(target = "bdr", ignore = true),
+            @Mapping(source = "ratio", target = "value")
     })
     BdrParidadeEntity toEntity(ParidadeBdr paridade);
 


### PR DESCRIPTION
## Summary
- alinhar o campo de paridade para persistir na coluna `value`
- configurar a coluna `method` para usar o tipo PostgreSQL `paridade_method_enum`

