### PR TITLE
Map parity mapper fields and support enum

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrParidadeEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrParidadeEntity.java
@@ -1,5 +1,6 @@
 package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr;
 
+import br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.converter.ParidadeMethodAttributeConverter;
 import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.ParidadeMethod;
 import jakarta.persistence.*;
 import lombok.*;
@@ -27,7 +28,7 @@ public class BdrParidadeEntity {
     @Column(name = "value")
     private Integer value;
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = ParidadeMethodAttributeConverter.class)
     @Column(name = "method", columnDefinition = "paridade_method_enum")
     private ParidadeMethod method;
 

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/converter/ParidadeMethodAttributeConverter.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/converter/ParidadeMethodAttributeConverter.java
@@ -1,0 +1,25 @@
+package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.jpa.bdr.converter;
+
+import br.dev.rodrigopinheiro.tickerscraper.domain.model.bdr.ParidadeMethod;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class ParidadeMethodAttributeConverter implements AttributeConverter<ParidadeMethod, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ParidadeMethod attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.name();
+    }
+
+    @Override
+    public ParidadeMethod convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return ParidadeMethod.valueOf(dbData);
+    }
+}

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrParidadeMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrParidadeMapper.java
@@ -13,7 +13,11 @@ public interface BdrParidadeMapper {
     @Mappings({
             @Mapping(target = "id", ignore = true),
             @Mapping(target = "bdr", ignore = true),
-            @Mapping(source = "ratio", target = "value")
+            @Mapping(source = "ratio", target = "value"),
+            @Mapping(source = "method", target = "method"),
+            @Mapping(source = "confidence", target = "confidence"),
+            @Mapping(source = "lastVerifiedAt", target = "lastVerifiedAt"),
+            @Mapping(source = "raw", target = "raw")
     })
     BdrParidadeEntity toEntity(ParidadeBdr paridade);
 


### PR DESCRIPTION
## Summary
- update the BDR parity mapper to cover the new domain and entity fields
- introduce a JPA attribute converter so the ParidadeMethod enum can be stored in the Postgres paridade_method_enum type

## Testing
- `./tickerscraper/mvnw -f tickerscraper/pom.xml test` *(fails: unable to download Spring Boot parent POM because the Maven Central host is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d42b83e5ec832a99411cc6c02ccf51