### PR TITLE
Adjust BDR price series time mapping

### DIFF
--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrPriceSeriesEntity.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/jpa/bdr/BdrPriceSeriesEntity.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
 
 @Entity
 @Table(name = "bdr_price_series")
@@ -24,7 +24,7 @@ public class BdrPriceSeriesEntity {
     private BdrEntity bdr;
 
     @Column(name = "dt", nullable = false)
-    private LocalDate dt;
+    private OffsetDateTime dt;
 
     @Column(name = "close", precision = 19, scale = 6, nullable = false)
     private BigDecimal close;

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrPriceSeriesMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/BdrPriceSeriesMapper.java
@@ -9,7 +9,7 @@ import org.mapstruct.Mappings;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = TimeMapper.class)
 public interface BdrPriceSeriesMapper {
 
     @Mappings({

--- a/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/TimeMapper.java
+++ b/tickerscraper/src/main/java/br/dev/rodrigopinheiro/tickerscraper/adapter/output/persistence/mapper/bdr/TimeMapper.java
@@ -3,6 +3,7 @@ package br.dev.rodrigopinheiro.tickerscraper.adapter.output.persistence.mapper.b
 import org.mapstruct.Mapper;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
@@ -15,5 +16,13 @@ public interface TimeMapper {
 
     default Instant toInstant(OffsetDateTime offsetDateTime) {
         return offsetDateTime == null ? null : offsetDateTime.toInstant();
+    }
+
+    default OffsetDateTime toOffsetDateTime(LocalDate date) {
+        return date == null ? null : date.atStartOfDay().atOffset(ZoneOffset.UTC);
+    }
+
+    default LocalDate toLocalDate(OffsetDateTime offsetDateTime) {
+        return offsetDateTime == null ? null : offsetDateTime.toLocalDate();
     }
 }


### PR DESCRIPTION
## Summary
- update the BDR price series entity to persist timestamps as `OffsetDateTime`
- extend the shared time mapper to convert between `LocalDate` and `OffsetDateTime`
- wire the price series MapStruct mapper to reuse the updated time conversions and drop legacy field mappings

